### PR TITLE
chore: add cursor rule to enforce reading AGENTS.md first

### DIFF
--- a/.cursor/rules/read-agents-first.mdc
+++ b/.cursor/rules/read-agents-first.mdc
@@ -1,0 +1,15 @@
+---
+description: Always read AGENTS.md before making any changes
+alwaysApply: true
+---
+
+# Read AGENTS.md First
+
+Before doing ANY work in this repository, you MUST read `/AGENTS.md` at the project root.
+
+This file contains:
+- Coding standards and conventions
+- Git workflow rules (strict GitHub Flow)
+- Permission requirements for git operations
+
+Do not skip this step. Do not assume you know the contents. Read it every time.

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ Thumbs.db
 *.swp
 *.swo
 
+# Cursor (track rules, ignore workspace state)
+.cursor/*
+!.cursor/rules/
+
 # Local dev scripts and internal docs (kept on disk, not in repo)
 bin/
 glubean-dev


### PR DESCRIPTION
## Summary
- Track `.cursor/rules/` in git (update `.gitignore` to ignore other `.cursor/` state)
- Add always-apply Cursor rule that requires agents to read `AGENTS.md` before any work

## Test plan
- Verify `.cursor/rules/read-agents-first.mdc` is tracked
- Start a new Cursor conversation and confirm the rule is injected

Made with [Cursor](https://cursor.com)