### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/packages/auth/deno.json
+++ b/packages/auth/deno.json
@@ -1,13 +1,13 @@
 {
   "name": "@glubean/auth",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "exports": {
     ".": "./mod.ts"
   },
   "license": "MIT",
   "description": "Auth helpers for Glubean — bearer, basic, apiKey, OAuth 2.0, and dynamic login",
   "imports": {
-    "@glubean/sdk": "jsr:@glubean/sdk@^0.10.0",
+    "@glubean/sdk": "jsr:@glubean/sdk@^0.11.0",
     "@std/encoding": "jsr:@std/encoding@^1.0.0"
   },
   "publish": {

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",
@@ -8,10 +8,10 @@
     "exclude": ["*_test.ts", ".glubean/"]
   },
   "imports": {
-    "@glubean/sdk": "jsr:@glubean/sdk@^0.10.0",
+    "@glubean/sdk": "jsr:@glubean/sdk@^0.11.0",
     "@glubean/runner": "jsr:@glubean/runner@^0.11.0",
     "@glubean/scanner": "jsr:@glubean/scanner@^0.11.0",
-    "@glubean/redaction": "jsr:@glubean/redaction@^0.10.0",
+    "@glubean/redaction": "jsr:@glubean/redaction@^0.11.0",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.8",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "@std/path": "jsr:@std/path@^1.0.0",

--- a/packages/graphql/deno.json
+++ b/packages/graphql/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/graphql",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts"
@@ -8,7 +8,7 @@
   "license": "MIT",
   "description": "GraphQL plugin for Glubean — wraps ctx.http with query/mutation helpers and auto-tracing",
   "imports": {
-    "@glubean/sdk": "jsr:@glubean/sdk@^0.10.0"
+    "@glubean/sdk": "jsr:@glubean/sdk@^0.11.0"
   },
   "publish": {
     "exclude": [

--- a/packages/mcp/deno.json
+++ b/packages/mcp/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/mcp",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean MCP server - run checks and fetch facts for AI agents",

--- a/packages/redaction/deno.json
+++ b/packages/redaction/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/redaction",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Redaction Engine - Plugin-based secrets/PII detection and masking"

--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "description": "Glubean Runner - Test executor with sandboxed Deno subprocess",
   "imports": {
-    "@glubean/sdk": "jsr:@glubean/sdk@^0.10.0",
+    "@glubean/sdk": "jsr:@glubean/sdk@^0.11.0",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "@std/assert": "jsr:@std/assert@^1.0.0",
     "ky": "npm:ky@^1.14.0"

--- a/packages/sdk/deno.json
+++ b/packages/sdk/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/sdk",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts",

--- a/packages/worker/deno.json
+++ b/packages/worker/deno.json
@@ -13,8 +13,8 @@
   },
   "imports": {
     "@glubean/runner": "jsr:@glubean/runner@^0.11.0",
-    "@glubean/redaction": "jsr:@glubean/redaction@^0.10.0",
-    "@glubean/sdk": "jsr:@glubean/sdk@^0.10.0",
+    "@glubean/redaction": "jsr:@glubean/redaction@^0.11.0",
+    "@glubean/sdk": "jsr:@glubean/sdk@^0.11.0",
     "@std/tar": "jsr:@std/tar@^0.1",
     "@std/tar/untar-stream": "jsr:@std/tar@^0.1/untar-stream",
     "@std/path": "jsr:@std/path@^1",


### PR DESCRIPTION
## Summary

- Bumps all 9 workspace packages from mixed versions (0.10.1/0.11.0) to a unified **0.11.0**
- Required so `@glubean/scanner@0.11.0` (with correct `static` subpath export) can be published to JSR
- Unblocks the `glubean/vscode` CI which depends on `@glubean/scanner/static`

## Packages bumped

`@glubean/auth`, `@glubean/cli`, `@glubean/graphql`, `@glubean/mcp`, `@glubean/redaction`, `@glubean/runner`, `@glubean/scanner`, `@glubean/sdk`, `@glubean/worker`

## Test plan

- [x] `deno fmt --check` passes
- [x] `deno test -A` passes (673 passed, 0 failed)

Made with [Cursor](https://cursor.com)