### PR TITLE
fix: pre-release final touch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ The CLI `init` command (`packages/cli/commands/init.ts`) generates starter proje
 **When bumping versions or changing conventions, always check:**
 
 - `packages/cli/commands/init.ts` — SDK version in `makeDenoJson()` and `PLAYGROUND_DENO_JSON` (e.g.
-  `jsr:@glubean/sdk@^0.10.0`)
+  `jsr:@glubean/sdk@^0.11.0`)
 - `packages/cli/templates/*.test.ts` — import paths, API usage, assertion methods must reflect the current SDK
 - `packages/cli/templates/AGENTS.md` — the assertion method list and API examples must match the current SDK surface
 - `packages/cli/commands/init_test.ts` — version assertion in the test that verifies generated `deno.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 All notable changes to the Glubean OSS project will be documented in this file.
 
+## 0.11.0
+
+### New Packages
+
+- **`@glubean/auth`** — Auth helpers for bearer, basic, apiKey, OAuth 2.0, and dynamic login flows
+- **`@glubean/graphql`** — GraphQL plugin with `.query()` / `.mutate()` helpers, `.gql` file loading, and auto-tracing
+
+### @glubean/sdk
+
+- **Builder API** — `test(id).setup(fn).step(name, fn).teardown(fn)` for multi-step tests with typed state
+- **`test.each()`** — Data-driven test generation from arrays, CSV, YAML, JSONL, or directories
+- **`test.pick()`** — Example-driven tests with random selection or pinned examples via `--pick`
+- **Plugin composition** — `.use(fn)` and `.group(id, fn)` for reusable step sequences
+- **`ctx.expect()`** — Fluent assertion API (soft by default, `.orFail()` for guards, `.not` for negation)
+- **`ctx.warn()`** — Non-failing soft checks for best-practice validation
+- **`ctx.validate()`** — Schema validation with any library (Zod, Valibot, ArkType) and severity control (`error` /
+  `warn` / `fatal`)
+- **HTTP schema auto-validation** — `schema: { request, response, query }` option on `ctx.http` calls
+- **`ctx.pollUntil()`** — Async polling with configurable interval and timeout
+- **`ctx.setTimeout()`** — Dynamic test timeout adjustment
+- **`configure()`** — File-level shared setup with prefixUrl, headers, hooks, and plugins
+- **Template placeholders** — `{{key}}` in headers resolved from vars/secrets (now supports hyphenated keys like
+  `{{X-API-KEY}}`)
+- **Data loaders** — `fromCsv()`, `fromYaml()`, `fromJsonl()`, `fromDir()` for `test.each()`
+
+### @glubean/cli
+
+- **`glubean context`** — Generate AI context file from OpenAPI spec
+- **`glubean coverage`** — API endpoint test coverage report against OpenAPI spec
+- **`glubean diff`** — OpenAPI spec change detection (vs git HEAD)
+- **Directory convention** — `tests/` and `explore/` directories replace `*.explore.ts` suffix
+- **`glubean run`** — Defaults to `testDir`, `--explore` scans `exploreDir`
+- **Unified .env parsing** — Replaced hand-rolled parser with `@std/dotenv` for robust handling of quotes, comments, and
+  special characters
+- **Update checker** — Improved semver comparison with pre-release support
+- **Bump script** — Now also updates template SDK version constants and testdata imports
+
+### @glubean/runner
+
+- HTTP interception and auto-tracing
+- Structured event streaming (logs, assertions, traces, metrics, warnings)
+- V8 Inspector debug support (`--inspect-brk`)
+- Timeout, retry, and fail-fast handling
+
+### @glubean/mcp
+
+- Unified .env parsing with `@std/dotenv`
+
 ## 2026-02-13
 
 ### @glubean/cli

--- a/deno.json
+++ b/deno.json
@@ -28,7 +28,8 @@
     "@std/encoding": "jsr:@std/encoding@^1.0.0",
     "@std/assert": "jsr:@std/assert@^1.0.0",
     "@std/tar": "jsr:@std/tar@^0.1.0",
-    "@std/io": "jsr:@std/io@^0.225.0"
+    "@std/io": "jsr:@std/io@^0.225.0",
+    "@std/dotenv": "jsr:@std/dotenv@^0.225.0"
   },
   "fmt": {
     "lineWidth": 120

--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -127,12 +127,14 @@ async function resolveContent(
 // Templates — Standard project
 // ---------------------------------------------------------------------------
 
+const SDK_VERSION = "^0.11.0";
+
 function makeDenoJson(_baseUrl: string): string {
   return (
     JSON.stringify(
       {
         imports: {
-          "@glubean/sdk": "jsr:@glubean/sdk@^0.10.0",
+          "@glubean/sdk": `jsr:@glubean/sdk@${SDK_VERSION}`,
         },
         tasks: {
           test: "deno run -A jsr:@glubean/cli run",
@@ -257,7 +259,7 @@ jobs:
 
 const PLAYGROUND_DENO_JSON = `{
   "imports": {
-    "@glubean/sdk": "jsr:@glubean/sdk@^0.10.0"
+    "@glubean/sdk": "jsr:@glubean/sdk@${SDK_VERSION}"
   },
   "tasks": {
     "test": "deno run -A jsr:@glubean/cli run",

--- a/packages/cli/commands/init_test.ts
+++ b/packages/cli/commands/init_test.ts
@@ -99,7 +99,7 @@ Deno.test("init --no-interactive creates basic project files", async () => {
     );
     assertEquals(
       denoJson.imports?.["@glubean/sdk"],
-      "jsr:@glubean/sdk@^0.10.0",
+      "jsr:@glubean/sdk@^0.11.0",
     );
     assertEquals(typeof denoJson.tasks?.scan, "string");
     assertEquals(typeof denoJson.tasks?.["validate-metadata"], "string");

--- a/packages/cli/commands/run.ts
+++ b/packages/cli/commands/run.ts
@@ -1,5 +1,6 @@
 import { type ExecutionEvent, TestExecutor, toSingleExecutionOptions } from "@glubean/runner";
 import { basename, relative, resolve, toFileUrl } from "@std/path";
+import { parse as parseDotenv } from "@std/dotenv/parse";
 import { loadConfig, mergeRunOptions, toSharedRunConfig } from "../lib/config.ts";
 import { walk } from "@std/fs/walk";
 import { expandGlob } from "@std/fs/expand-glob";
@@ -127,33 +128,13 @@ async function findProjectConfig(
   return { rootDir: startDir };
 }
 
-/**
- * Load environment variables from a .env file.
- */
 async function loadEnvFile(envPath: string): Promise<Record<string, string>> {
-  const vars: Record<string, string> = {};
   try {
     const content = await Deno.readTextFile(envPath);
-    for (const line of content.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) continue;
-      const eqIndex = trimmed.indexOf("=");
-      if (eqIndex === -1) continue;
-      const key = trimmed.slice(0, eqIndex).trim();
-      let value = trimmed.slice(eqIndex + 1).trim();
-      // Remove surrounding quotes if present
-      if (
-        (value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))
-      ) {
-        value = value.slice(1, -1);
-      }
-      vars[key] = value;
-    }
+    return parseDotenv(content);
   } catch {
-    // File doesn't exist, return empty
+    return {};
   }
-  return vars;
 }
 
 // ── SDK import patterns (mirrors @glubean/scanner) ──────────────────────────

--- a/packages/mcp/mod.ts
+++ b/packages/mcp/mod.ts
@@ -14,6 +14,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 
 import { dirname, resolve, toFileUrl } from "@std/path";
+import { parse } from "@std/dotenv/parse";
 import { crypto } from "@std/crypto";
 import { encodeHex } from "@std/encoding/hex";
 import { LOCAL_RUN_DEFAULTS, resolveModuleTests, TestExecutor, toSingleExecutionOptions } from "@glubean/runner";
@@ -40,28 +41,12 @@ async function findProjectRoot(startDir: string): Promise<string> {
 }
 
 async function loadEnvFile(envPath: string): Promise<Vars> {
-  const vars: Vars = {};
   try {
     const content = await Deno.readTextFile(envPath);
-    for (const line of content.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) continue;
-      const eqIndex = trimmed.indexOf("=");
-      if (eqIndex === -1) continue;
-      const key = trimmed.slice(0, eqIndex).trim();
-      let value = trimmed.slice(eqIndex + 1).trim();
-      if (
-        (value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))
-      ) {
-        value = value.slice(1, -1);
-      }
-      vars[key] = value;
-    }
+    return parse(content);
   } catch {
-    // missing env file is allowed
+    return {};
   }
-  return vars;
 }
 
 function normalizeFilePath(path: string): string {

--- a/packages/scanner/testdata/sample-project/api.test.ts
+++ b/packages/scanner/testdata/sample-project/api.test.ts
@@ -7,7 +7,7 @@
  * API Reference: @openapi.json
  */
 // deno-lint-ignore no-import-prefix
-import { test } from "jsr:@glubean/sdk@^0.10.0";
+import { test } from "jsr:@glubean/sdk@^0.11.0";
 
 // ============================================================================
 // Posts API Tests

--- a/packages/sdk/configure.ts
+++ b/packages/sdk/configure.ts
@@ -137,7 +137,7 @@ function requireSecret(key: string): string {
 /**
  * Regex for `{{key}}` template placeholders in header values.
  */
-const TEMPLATE_RE = /\{\{(\w+)\}\}/g;
+const TEMPLATE_RE = /\{\{([\w-]+)\}\}/g;
 
 /**
  * Build a lazy vars accessor object.

--- a/packages/sdk/configure_test.ts
+++ b/packages/sdk/configure_test.ts
@@ -648,6 +648,32 @@ Deno.test("http - header without template placeholders passed as-is", () => {
   }
 });
 
+Deno.test("http - resolves hyphenated {{X-API-KEY}} template placeholders", () => {
+  const extendCalls: { options: HttpRequestOptions }[] = [];
+  const mockHttp = createMockHttp(extendCalls);
+  const cleanup = setRuntime(
+    {},
+    { "X-API-KEY": "key-abc-123", "AWS-REGION": "us-east-1" },
+    mockHttp,
+  );
+  try {
+    const { http } = configure({
+      http: {
+        headers: {
+          "X-Api-Key": "{{X-API-KEY}}",
+          "X-Region": "{{AWS-REGION}}",
+        },
+      },
+    });
+    http.get("https://example.com");
+    const headers = extendCalls[0].options.headers as Record<string, string>;
+    assertEquals(headers["X-Api-Key"], "key-abc-123");
+    assertEquals(headers["X-Region"], "us-east-1");
+  } finally {
+    cleanup();
+  }
+});
+
 // =============================================================================
 // HTTP hooks passthrough
 // =============================================================================

--- a/packages/sdk/expect_test.ts
+++ b/packages/sdk/expect_test.ts
@@ -104,6 +104,36 @@ Deno.test("deepEqual - Map and Set", () => {
   assertEquals(deepEqual(new Set([1, 2]), new Set([1, 3])), false);
 });
 
+Deno.test("deepEqual - circular references do not cause stack overflow", () => {
+  // deno-lint-ignore no-explicit-any
+  const a: any = { x: 1 };
+  a.self = a;
+  // deno-lint-ignore no-explicit-any
+  const b: any = { x: 1 };
+  b.self = b;
+  assertEquals(deepEqual(a, b), true);
+
+  // deno-lint-ignore no-explicit-any
+  const c: any = { x: 2 };
+  c.self = c;
+  assertEquals(deepEqual(a, c), false);
+
+  // Mutual circular references
+  // deno-lint-ignore no-explicit-any
+  const d: any = { val: "d" };
+  // deno-lint-ignore no-explicit-any
+  const e: any = { val: "d" };
+  d.ref = e;
+  e.ref = d;
+  // deno-lint-ignore no-explicit-any
+  const f: any = { val: "d" };
+  // deno-lint-ignore no-explicit-any
+  const g: any = { val: "d" };
+  f.ref = g;
+  g.ref = f;
+  assertEquals(deepEqual(d, f), true);
+});
+
 // =============================================================================
 // toBe — strict equality
 // =============================================================================

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -5,7 +5,7 @@
  *
  * Updates:
  * - Every packages/x/deno.json version field
- * - Cross-references like @glubean/sdk: jsr:@glubean/sdk@^0.10.0
+ * - Cross-references like @glubean/sdk: jsr:@glubean/sdk@^0.11.0
  *
  * Usage:
  *   deno task version 0.10.1
@@ -95,7 +95,7 @@ for (const pkgPath of packagePaths) {
   );
 
   // Update @glubean/* cross-references in imports
-  // e.g. "jsr:@glubean/sdk@^0.10.0" → "jsr:@glubean/sdk@^0.11.0"
+  // e.g. "jsr:@glubean/sdk@^0.11.0" → "jsr:@glubean/sdk@^0.12.0"
   content = content.replace(
     /("jsr:@glubean\/[^@]+@)\^?\d+\.\d+\.\d+"/g,
     `$1${caretRange}"`,
@@ -103,6 +103,34 @@ for (const pkgPath of packagePaths) {
 
   await Deno.writeTextFile(pkgPath, content);
   console.log(`  ✓ ${name} (packages/${pkgDir}/deno.json)`);
+}
+
+// Update SDK_VERSION constant in CLI init template
+const initTsPath = resolve(PACKAGES_DIR, "cli", "commands", "init.ts");
+try {
+  let initContent = await Deno.readTextFile(initTsPath);
+  initContent = initContent.replace(
+    /const SDK_VERSION = "[^"]+"/,
+    `const SDK_VERSION = "${caretRange}"`,
+  );
+  await Deno.writeTextFile(initTsPath, initContent);
+  console.log(`  ✓ packages/cli/commands/init.ts (SDK_VERSION)`);
+} catch {
+  console.error(`  ✗ Failed to update init.ts`);
+}
+
+// Update scanner testdata sample import
+const testdataPath = resolve(PACKAGES_DIR, "scanner", "testdata", "sample-project", "api.test.ts");
+try {
+  let tdContent = await Deno.readTextFile(testdataPath);
+  tdContent = tdContent.replace(
+    /jsr:@glubean\/sdk@\^[\d.]+/g,
+    `jsr:@glubean/sdk@${caretRange}`,
+  );
+  await Deno.writeTextFile(testdataPath, tdContent);
+  console.log(`  ✓ packages/scanner/testdata/sample-project/api.test.ts`);
+} catch {
+  console.error(`  ✗ Failed to update scanner testdata`);
 }
 
 console.log(`\nDone. All packages bumped to ${newVersion}`);


### PR DESCRIPTION
## Summary

Pre-release quality sweep addressing all items from the deep review document.

- **Critical**: Align SDK version in templates to `^0.11.0`, extract `SDK_VERSION` constant to prevent future drift
- **High**: Replace hand-rolled `.env` parsers in MCP and CLI with `@std/dotenv`; support hyphens in `{{X-API-KEY}}` template placeholders
- **Medium**: Protect `deepEqual` against circular references; full semver pre-release comparison (rc.2 > rc.1, build metadata neutrality); extend bump script to update init.ts and scanner testdata; add `0.11.0` CHANGELOG; enhance root README with builder/test.each examples and missing packages (`@glubean/auth`, `@glubean/graphql`)

### Files changed (16)

| Area | Files |
|------|-------|
| Templates | `packages/cli/commands/init.ts`, `init_test.ts`, `packages/scanner/testdata/sample-project/api.test.ts` |
| Env parsing | `packages/mcp/mod.ts`, `packages/cli/commands/run.ts`, `deno.json` |
| SDK | `packages/sdk/configure.ts`, `configure_test.ts`, `expect.ts`, `expect_test.ts` |
| CLI | `packages/cli/update_check.ts`, `update_check_test.ts` |
| Scripts | `scripts/bump-version.ts` |
| Docs | `CHANGELOG.md`, `README.md`, `AGENTS.md` |

## Test plan

- [x] `deno task lint` passes
- [x] `deno task check` passes (fmt + type check)
- [x] `deno test -A packages/sdk/configure_test.ts` — hyphenated placeholder test
- [x] `deno test -A packages/sdk/expect_test.ts` — circular reference test
- [x] `deno test -A packages/cli/update_check_test.ts` — 8 tests including pre-release ordering
- [ ] `deno task test` full suite

Made with [Cursor](https://cursor.com)