### PR TITLE
fix(cli): derive CLI_VERSION from deno.json instead of hardcoded string

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",

--- a/packages/cli/version.ts
+++ b/packages/cli/version.ts
@@ -1,1 +1,3 @@
-export const CLI_VERSION = "0.2.25";
+import denoConfig from "./deno.json" with { type: "json" };
+
+export const CLI_VERSION: string = denoConfig.version;


### PR DESCRIPTION
## Summary

- **`version.ts`**: now imports `deno.json` to derive `CLI_VERSION` instead of a hardcoded string that was stuck at `0.2.25`
- **`@glubean/cli` bumped to `0.11.1`** (already published to JSR)
- **New `auto-patch.yml` workflow**: when a PR merges to main with a patch version bump in any `packages/*/deno.json`, that package is automatically published to JSR
- **Updated `release.yml`**: version consistency check now enforces major.minor alignment only, allowing independent patch versions

### New release strategy

| Trigger | Scope | Workflow |
|---------|-------|----------|
| PR merge to main (patch bump) | Only changed packages | `auto-patch.yml` |
| GitHub Release / workflow_dispatch | All packages (unified version) | `release.yml` |

## Test plan

- [x] `deno test packages/cli/ -A` — 64 passed, 0 failed
- [x] `deno eval` confirms `CLI_VERSION` reads `0.11.1` from `deno.json`
- [x] `@glubean/cli@0.11.1` published and verified (`glubean -V` → `0.11.1`)
- [ ] Merge this PR and verify `auto-patch.yml` does NOT trigger (CLI already published at 0.11.1)