### PR TITLE
fix: group test.pick traces into single directory for diffing

### DIFF
--- a/packages/scanner/extractor-deno.ts
+++ b/packages/scanner/extractor-deno.ts
@@ -107,6 +107,7 @@ function processExport(name, value) {
     };
     if (value.meta.skip) entry.skip = true;
     if (value.meta.only) entry.only = true;
+    if (reg && reg.groupId) entry.groupId = reg.groupId;
     exports.push(entry);
     seenIds.add(value.meta.id);
   }
@@ -162,6 +163,7 @@ for (const reg of registry) {
     };
     if (reg.skip) entry.skip = true;
     if (reg.only) entry.only = true;
+    if (reg.groupId) entry.groupId = reg.groupId;
     exports.push(entry);
   }
 }

--- a/packages/scanner/extractor-deno_test.ts
+++ b/packages/scanner/extractor-deno_test.ts
@@ -79,6 +79,7 @@ Deno.test("extractWithDeno — test.each simple mode expands rows", async () => 
   assertExists(item2, "should discover 'item-2'");
   assertEquals(item1.exportName, "items");
   assertEquals(item2.exportName, "items");
+  assertEquals(item1.groupId, undefined, "each tests should not have groupId");
 });
 
 Deno.test("extractWithDeno — test.each builder mode expands rows", async () => {
@@ -98,6 +99,7 @@ Deno.test("extractWithDeno — test.pick", async () => {
   const picks = results.filter((r) => r.id.startsWith("p-"));
   assertEquals(picks.length >= 1, true, "should discover at least one test.pick test");
   assertEquals(picks[0].exportName, "pick");
+  assertEquals(picks[0].groupId, "p-$_pick", "pick tests should have groupId = template ID");
 });
 
 Deno.test("extractWithDeno — only flag propagated", async () => {

--- a/packages/scanner/types.ts
+++ b/packages/scanner/types.ts
@@ -28,6 +28,15 @@ export interface ExportMeta {
    * `test.each` from `test.pick` since both produce `EachBuilder` objects.
    */
   variant?: "each" | "pick";
+  /**
+   * Trace grouping ID — the unresolved template ID for pick tests.
+   * When set, the CLI uses this as the trace directory name so all
+   * pick variants share one directory for easy diffing.
+   *
+   * Populated by runtime extraction when the SDK sets `groupId` on
+   * registered test metadata (i.e., for `test.pick` tests).
+   */
+  groupId?: string;
   /** JavaScript export name (e.g., "myTest" or "default") */
   exportName: string;
   /** Source location */

--- a/packages/sdk/mod.ts
+++ b/packages/sdk/mod.ts
@@ -870,6 +870,7 @@ export class EachBuilder<
       ...(s.meta.group ? { group: s.meta.group } : {}),
     }));
     const table = this._filteredTable();
+    const isPick = table.length > 0 && "_pick" in table[0];
     for (let i = 0; i < table.length; i++) {
       const row = table[i];
       const id = interpolateTemplate(this._baseMeta.id, row, i);
@@ -884,6 +885,7 @@ export class EachBuilder<
         steps: stepMetas,
         hasSetup: !!this._setup,
         hasTeardown: !!this._teardown,
+        ...(isPick ? { groupId: this._baseMeta.id } : {}),
       });
     }
   }
@@ -1176,6 +1178,7 @@ function createExtendedTest<Ctx extends TestContext>(
         : table;
       const tagFieldNames = toArray(baseMeta.tagFields);
       const staticTags = toArray(baseMeta.tags);
+      const isPick = filteredTable.length > 0 && "_pick" in filteredTable[0];
 
       return filteredTable.map((row, index) => {
         const id = interpolateTemplate(baseMeta.id, row, index);
@@ -1208,6 +1211,7 @@ function createExtendedTest<Ctx extends TestContext>(
           type: "simple",
           tags: allTags.length > 0 ? allTags : undefined,
           description: meta.description,
+          ...(isPick ? { groupId: baseMeta.id } : {}),
         });
 
         return testDef;
@@ -1312,6 +1316,7 @@ export namespace test {
 
       const tagFieldNames = toArray(baseMeta.tagFields);
       const staticTags = toArray(baseMeta.tags);
+      const isPick = filteredTable.length > 0 && "_pick" in filteredTable[0];
 
       // Simple mode: with callback → return Test[]
       return filteredTable.map((row, index) => {
@@ -1346,6 +1351,7 @@ export namespace test {
           type: "simple",
           tags: allTags.length > 0 ? allTags : undefined,
           description: meta.description,
+          ...(isPick ? { groupId: baseMeta.id } : {}),
         });
 
         return testDef;

--- a/packages/sdk/mod_test.ts
+++ b/packages/sdk/mod_test.ts
@@ -1253,3 +1253,33 @@ Deno.test("test.pick - registers tests in global registry", () => {
     Deno.env.delete("GLUBEAN_PICK");
   }
 });
+
+Deno.test("test.pick - sets groupId to template ID in registry", () => {
+  clearRegistry();
+  Deno.env.set("GLUBEAN_PICK", "normal,admin");
+
+  try {
+    test.pick(pickExamples)("pick-$_pick", async () => {});
+
+    const reg = getRegistry();
+    assertEquals(reg.length, 2);
+    assertEquals(reg[0].groupId, "pick-$_pick");
+    assertEquals(reg[1].groupId, "pick-$_pick");
+  } finally {
+    Deno.env.delete("GLUBEAN_PICK");
+  }
+});
+
+Deno.test("test.each - does not set groupId in registry", () => {
+  clearRegistry();
+
+  test.each([
+    { id: 1, name: "a" },
+    { id: 2, name: "b" },
+  ])("each-$id", async () => {});
+
+  const reg = getRegistry();
+  assertEquals(reg.length, 2);
+  assertEquals(reg[0].groupId, undefined);
+  assertEquals(reg[1].groupId, undefined);
+});

--- a/packages/sdk/types.ts
+++ b/packages/sdk/types.ts
@@ -1581,4 +1581,10 @@ export interface RegisteredTestMeta {
   file?: string;
   /** Export name in the module */
   exportName?: string;
+  /**
+   * Trace grouping ID — the unresolved template ID for pick tests.
+   * When set, the CLI uses this as the trace directory name so all
+   * pick variants land in one directory for easy diffing.
+   */
+  groupId?: string;
 }


### PR DESCRIPTION
## Summary

- **Problem**: `test.pick` created separate trace directories per variant (e.g., `search-by-name/`, `search-by-category/`), each with only one trace file. This broke diff ("need at least two runs"), CodeLens trace counts, and trace navigation.
- **Fix**: Propagate a `groupId` (= unresolved template ID like `search-$_pick`) from SDK → scanner → CLI. The CLI uses `groupId` as the trace directory name and encodes the resolved test ID in the filename: `{timestamp}--{testId}.trace.jsonc`.
- **Bonus**: Upgraded trace timestamps from minute to second precision to prevent overwrites on rapid re-runs. Added `sanitizeForPath()` for path safety.

### Before
```
.glubean/traces/search.test/
  search-by-category/
    20260220T0759.trace.jsonc
  search-by-name/
    20260220T0758.trace.jsonc
```

### After
```
.glubean/traces/search.test/
  search-$_pick/
    20260220T075803--search-by-name.trace.jsonc
    20260220T075912--search-by-category.trace.jsonc
```

## Changes

| Package | File | Change |
|---------|------|--------|
| SDK | `types.ts` | Add `groupId?: string` to `RegisteredTestMeta` |
| SDK | `mod.ts` | Detect pick tests via `_pick` field, set `groupId` in `registerTest()` calls (builder + simple modes) |
| Scanner | `types.ts` | Add `groupId?: string` to `ExportMeta` |
| Scanner | `extractor-deno.ts` | Propagate `groupId` from registry to extracted metadata |
| CLI | `run.ts` | Thread `groupId` through discovery/collection, use for trace dir naming; add seconds to timestamp; add `sanitizeForPath()` |

## Test plan

- [x] SDK: 73 tests pass (`deno test packages/sdk/mod_test.ts --allow-env`)
- [x] Scanner: 70 tests pass (`deno test packages/scanner/ --allow-all`)
- [x] CLI: type-check clean (`deno check packages/cli/commands/run.ts`)
- [x] New tests: `test.pick` sets `groupId` in registry; `test.each` does not
- [x] `deno fmt --check` and `deno lint` pass
- [ ] E2E: run `test.pick` file, verify trace directory structure (requires published packages)

Companion PR: glubean/vscode (diff label improvements)

Made with [Cursor](https://cursor.com)