### PR TITLE
fix: bump runner to 0.11.1 (unblocks CLI 0.11.2)

### DIFF
--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/runner",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Runner - Test executor with sandboxed Deno subprocess",


### PR DESCRIPTION
## Summary

- CLI 0.11.2 imports `normalizePositiveTimeoutMs` from `@glubean/runner`, but runner 0.11.0 doesn't export it (added after 0.11.0 was published)
- Users get: `SyntaxError: does not provide an export named 'normalizePositiveTimeoutMs'`
- One-line fix: bump runner version so auto-patch publishes 0.11.1

## Test plan

- [x] CI passes
- After merge: verify `jsr:@glubean/runner@0.11.1` is published, then `deno cache --reload` and run tests

Made with [Cursor](https://cursor.com)