### PR TITLE
fix: preserve JSON structure in trace body truncation

### DIFF
--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/runner",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Runner - Test executor with sandboxed Deno subprocess",


### PR DESCRIPTION
## Summary

- Raise `TRACE_BODY_MAX_SIZE` from 10KB to 1MB
- When truncation is still needed, prune arrays (keep first 3 items + count annotation) instead of collapsing the entire body to an escaped string
- Trace files stay valid JSON and diffable

## Problem

Responses exceeding 10KB (e.g., a product search returning 30 items) had their body stored as an escaped JSON string: `"body": "{\"products\":[{\"id\":101,..."`. This made trace files unreadable and broke diffing.

## Bump

- `@glubean/runner` 0.11.1 → 0.11.2 (internal behavior only, no export changes)

## Test plan

- [x] `deno test packages/runner/ -A` — 133 passed
- [x] `deno check` and `deno fmt` clean

Made with [Cursor](https://cursor.com)