### PR TITLE
chore(cli): bump to 0.11.3 - fix template imports

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
## Summary

Fixes CLI template files to use import map alias instead of hardcoded JSR URLs.

## Changes

- Bump `@glubean/cli` version from `0.11.2` to `0.11.3`
- Templates now correctly use `import { test } from "@glubean/sdk"` (the published 0.11.2 version still had hardcoded `jsr:@glubean/sdk@^0.11.0`)

## Why

When templates use hardcoded JSR URLs, Deno may resolve them to a different module instance than the scanner's import, causing a module-instance split. This breaks features like trace grouping that rely on a shared SDK registry.

## Test plan

- [x] Dry-run publish passes
- [ ] After merge: publish to JSR with `deno publish --cwd packages/cli`
- [ ] Test with `glubean init --minimal` and verify generated imports use `@glubean/sdk` alias


Made with [Cursor](https://cursor.com)