### PR TITLE
feat(cli): interactive arrow-key prompts for glubean init

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -13,6 +13,7 @@
     "@glubean/scanner": "jsr:@glubean/scanner@^0.11.0",
     "@glubean/redaction": "jsr:@glubean/redaction@^0.11.0",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.8",
+    "@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.8",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "@std/path": "jsr:@std/path@^1.0.0",
     "@std/fs": "jsr:@std/fs@^1.0.0",

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
## Summary

- Replace manual number-input prompts with Cliffy's arrow-key selection UI (`Select`, `Confirm`, `Input`) for a polished interactive experience
- Falls back to plain `readLine`-based prompts for piped stdin (test compatibility preserved)
- Add `@cliffy/prompt` dependency (same `^1.0.0-rc.8` range as the existing `@cliffy/command`)

## Test plan

- [x] `deno check` passes
- [x] All 21 init tests pass (piped stdin uses fallback path)
- [x] Manual test: `glubean init` in TTY shows arrow-key selection for project type, confirm prompts for Y/N, and inline-validated input for base URL

Made with [Cursor](https://cursor.com)