### PR TITLE
fix: correct search query and type shape in templates

### DIFF
--- a/packages/cli/templates/data/search-examples.json
+++ b/packages/cli/templates/data/search-examples.json
@@ -4,11 +4,11 @@
     "expected": { "minResults": 1, "titleContains": "phone" }
   },
   "by-category": {
-    "q": "laptops",
+    "q": "laptop",
     "expected": { "minResults": 1, "titleContains": "laptop" }
   },
   "no-results": {
     "q": "zzzznotreal",
-    "expected": { "minResults": 0 }
+    "expected": { "minResults": 0, "titleContains": "" }
   }
 }

--- a/packages/cli/templates/pick.test.ts.tpl
+++ b/packages/cli/templates/pick.test.ts.tpl
@@ -39,7 +39,7 @@ import createUserExamples from "../data/create-user.json" with { type: "json" };
  */
 export const searchProducts = test.pick({
   "by-name": { q: "phone", minPrice: 0, expected: "phone" },
-  "by-category": { q: "laptops", minPrice: 500, expected: "laptop" },
+  "by-category": { q: "laptop", minPrice: 500, expected: "laptop" },
   "empty-query": { q: "", minPrice: 0, expected: "" },
 })(
   "search-products-$_pick",


### PR DESCRIPTION
## Summary
- Change `"laptops"` to `"laptop"` in search template data (DummyJSON needs exact match)
- Add `titleContains: ""` to no-results example so all entries share the same type shape, fixing TS2339

## Test plan
- `glubean init` → search template should work against DummyJSON without 0 results
- No more TypeScript error on `expected.titleContains`

Made with [Cursor](https://cursor.com)