### PR TITLE
feat(cli): add --ci flag, default last-run.json, path args for --result-json/--reporter

### DIFF
--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -230,14 +230,14 @@ function makeDenoJson(_baseUrl: string): string {
           "@glubean/sdk": SDK_IMPORT,
         },
         tasks: {
-          test: "deno run -A jsr:@glubean/cli run",
-          "test:verbose": "deno run -A jsr:@glubean/cli run --verbose",
-          "test:staging": "deno run -A jsr:@glubean/cli run --env-file .env.staging",
-          "test:log": "deno run -A jsr:@glubean/cli run --log-file",
-          explore: "deno run -A jsr:@glubean/cli run --explore",
-          "explore:verbose": "deno run -A jsr:@glubean/cli run --explore --verbose",
-          scan: "deno run -A jsr:@glubean/cli scan",
-          "validate-metadata": "deno run -A jsr:@glubean/cli validate-metadata",
+          test: "glubean run",
+          "test:verbose": "glubean run --verbose",
+          "test:staging": "glubean run --env-file .env.staging",
+          "test:log": "glubean run --log-file",
+          explore: "glubean run --explore",
+          "explore:verbose": "glubean run --explore --verbose",
+          scan: "glubean scan",
+          "validate-metadata": "glubean validate-metadata",
         },
         glubean: {
           run: {
@@ -308,7 +308,7 @@ const GITIGNORE = `# Secrets (all env-specific secrets files)
 const PRE_COMMIT_HOOK = `#!/bin/sh
 set -e
 
-deno run -A jsr:@glubean/cli scan
+glubean scan
 
 if [ -n "$(git diff --name-only -- metadata.json)" ]; then
   echo "metadata.json updated. Please git add metadata.json"
@@ -319,7 +319,7 @@ fi
 const PRE_PUSH_HOOK = `#!/bin/sh
 set -e
 
-deno run -A jsr:@glubean/cli validate-metadata
+glubean validate-metadata
 `;
 
 const GITHUB_ACTION_METADATA = `name: Glubean Metadata
@@ -340,8 +340,10 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v2.x
+      - name: Install CLI
+        run: deno install -Agf -n glubean jsr:@glubean/cli
       - name: Generate metadata.json
-        run: deno run -A jsr:@glubean/cli scan
+        run: glubean scan
       - name: Verify metadata.json
         run: git diff --exit-code metadata.json
 `;
@@ -370,8 +372,11 @@ jobs:
           echo "USERNAME=\${{ secrets.USERNAME }}" >> .env.secrets
           echo "PASSWORD=\${{ secrets.PASSWORD }}" >> .env.secrets
 
+      - name: Install CLI
+        run: deno install -Agf -n glubean jsr:@glubean/cli
+
       - name: Run tests
-        run: deno run -A jsr:@glubean/cli run --fail-fast --reporter junit --result-json
+        run: glubean run --ci --result-json
 
       - name: Upload results
         if: always()
@@ -392,8 +397,8 @@ const MINIMAL_DENO_JSON = `{
     "@glubean/sdk": "${SDK_IMPORT}"
   },
   "tasks": {
-    "explore": "deno run -A jsr:@glubean/cli run --explore --verbose",
-    "scan": "deno run -A jsr:@glubean/cli scan"
+    "explore": "glubean run --explore --verbose",
+    "scan": "glubean scan"
   },
   "glubean": {
     "run": {

--- a/packages/cli/commands/init_test.ts
+++ b/packages/cli/commands/init_test.ts
@@ -278,14 +278,14 @@ Deno.test(
 
       const metadataContent = await Deno.readTextFile(metadataPath);
       assertEquals(metadataContent.includes("Glubean Metadata"), true);
-      assertEquals(metadataContent.includes("glubean/cli scan"), true);
+      assertEquals(metadataContent.includes("glubean scan"), true);
 
       const testsPath = join(dir, ".github/workflows/glubean-tests.yml");
       assertEquals(await fileExists(testsPath), true);
 
       const testsContent = await Deno.readTextFile(testsPath);
       assertEquals(testsContent.includes("Glubean Tests"), true);
-      assertEquals(testsContent.includes("glubean/cli run"), true);
+      assertEquals(testsContent.includes("glubean run --ci"), true);
       assertEquals(testsContent.includes("upload-artifact"), true);
     } finally {
       await cleanupDir(dir);
@@ -357,7 +357,7 @@ Deno.test(
       const preCommit = await Deno.readTextFile(
         join(dir, ".git/hooks/pre-commit"),
       );
-      assertEquals(preCommit.includes("glubean/cli scan"), true);
+      assertEquals(preCommit.includes("glubean scan"), true);
 
       const prePush = await Deno.readTextFile(join(dir, ".git/hooks/pre-push"));
       assertEquals(prePush.includes("validate-metadata"), true);

--- a/packages/cli/commands/run.ts
+++ b/packages/cli/commands/run.ts
@@ -4,7 +4,7 @@ import {
   TestExecutor,
   toSingleExecutionOptions,
 } from "@glubean/runner";
-import { basename, relative, resolve, toFileUrl } from "@std/path";
+import { basename, dirname, relative, resolve, toFileUrl } from "@std/path";
 import { parse as parseDotenv } from "@std/dotenv/parse";
 import { loadConfig, mergeRunOptions, toSharedRunConfig } from "../lib/config.ts";
 import { walk } from "@std/fs/walk";
@@ -56,16 +56,18 @@ interface RunOptions {
   failFast?: boolean;
   /** Stop after N test failures */
   failAfter?: number;
-  /** Write structured results to <testfile>.result.json for visualization */
-  resultJson?: boolean;
+  /** Write structured results — true for default path, string for custom path */
+  resultJson?: boolean | string;
   /** Emit full HTTP request/response headers and bodies in trace events */
   emitFullTrace?: boolean;
   /** Config file paths from --config (undefined = auto-read deno.json) */
   configFiles?: string[];
   /** Enable V8 Inspector for debugging (port number or true for default 9229) */
   inspectBrk?: number | boolean;
-  /** Output reporter format: "junit" writes JUnit XML */
+  /** Output reporter format, optionally with custom path: "junit" or "junit:/path/to/output.xml" */
   reporter?: string;
+  /** Custom path for JUnit XML output (parsed from --reporter junit:<path>) */
+  reporterPath?: string;
   /** Max trace files to keep per test (default: 20) */
   traceLimit?: number;
 }
@@ -1153,34 +1155,48 @@ export async function runCommand(
     }
   }
 
-  // ── Result JSON output (hidden flag) ────────────────────────────────────
+  // ── Result JSON output ───────────────────────────────────────────────────
+  // Always write .glubean/last-run.json for tooling (VS Code, viewer).
+  // When --result-json is set, also write to the explicit/default path.
+  const resultPayload = {
+    target,
+    files: testFiles.map((f) => relative(Deno.cwd(), f)),
+    runAt: runStartLocal,
+    summary: {
+      total: passed + failed + skipped,
+      passed,
+      failed,
+      skipped,
+      durationMs: totalDurationMs,
+      stats: runStats,
+    },
+    tests: collectedRuns.map((r) => ({
+      testId: r.testId,
+      testName: r.testName,
+      tags: r.tags,
+      success: r.success,
+      durationMs: r.durationMs,
+      events: r.events,
+    })),
+  };
+  const resultJson = JSON.stringify(resultPayload, null, 2);
+
+  try {
+    const glubeanDir = resolve(rootDir, ".glubean");
+    await Deno.mkdir(glubeanDir, { recursive: true });
+    await Deno.writeTextFile(resolve(glubeanDir, "last-run.json"), resultJson);
+  } catch {
+    // Non-critical
+  }
+
   if (options.resultJson) {
-    // resultJson stays as a direct CLI flag (not in config)
-    const resultPath = isMultiFile
+    const resultPath = typeof options.resultJson === "string"
+      ? resolve(options.resultJson)
+      : isMultiFile
       ? resolve(Deno.cwd(), "glubean-run.result.json")
       : getLogFilePath(testFiles[0]).replace(/\.log$/, ".result.json");
-    const result = {
-      target,
-      files: testFiles.map((f) => relative(Deno.cwd(), f)),
-      runAt: runStartLocal,
-      summary: {
-        total: passed + failed + skipped,
-        passed,
-        failed,
-        skipped,
-        durationMs: totalDurationMs,
-        stats: runStats,
-      },
-      tests: collectedRuns.map((r) => ({
-        testId: r.testId,
-        testName: r.testName,
-        tags: r.tags,
-        success: r.success,
-        durationMs: r.durationMs,
-        events: r.events,
-      })),
-    };
-    await Deno.writeTextFile(resultPath, JSON.stringify(result, null, 2));
+    await Deno.mkdir(dirname(resultPath), { recursive: true });
+    await Deno.writeTextFile(resultPath, resultJson);
     console.log(`${colors.dim}Result written to: ${resultPath}${colors.reset}`);
     console.log(
       `${colors.dim}Open ${colors.reset}${colors.cyan}https://glubean.com/viewer${colors.reset}${colors.dim} to visualize it${colors.reset}\n`,
@@ -1189,7 +1205,9 @@ export async function runCommand(
 
   // ── JUnit XML output ───────────────────────────────────────────────────
   if (options.reporter === "junit") {
-    const junitPath = isMultiFile
+    const junitPath = options.reporterPath
+      ? resolve(options.reporterPath)
+      : isMultiFile
       ? resolve(Deno.cwd(), "glubean-run.junit.xml")
       : getLogFilePath(testFiles[0]).replace(/\.log$/, ".junit.xml");
     const summaryData = {
@@ -1200,6 +1218,7 @@ export async function runCommand(
       durationMs: totalDurationMs,
     };
     const xml = toJunitXml(collectedRuns, target, summaryData);
+    await Deno.mkdir(dirname(junitPath), { recursive: true });
     await Deno.writeTextFile(junitPath, xml);
     console.log(
       `${colors.dim}JUnit XML written to: ${junitPath}${colors.reset}\n`,

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
## Summary
- Add `--ci` convenience flag (implies `--fail-fast` + `--reporter junit`)
- Always write `.glubean/last-run.json` after every run for tooling consumption
- `--result-json` now accepts an optional custom output path
- `--reporter` supports `junit:/path/to/output.xml` syntax for custom JUnit output paths
- Init templates use `glubean` commands directly instead of `deno run -A jsr:@glubean/cli`
- GitHub Actions templates install CLI globally and use `glubean run --ci`

## Test plan
- [x] All 68 existing CLI tests pass
- [ ] Manual: `glubean run --ci` produces JUnit XML and fails fast
- [ ] Manual: `glubean run --result-json ./out.json` writes to custom path
- [ ] Manual: `.glubean/last-run.json` written on every run
- [ ] Manual: `glubean init` produces updated templates


Made with [Cursor](https://cursor.com)