### PR TITLE
fix(cli): rename last-run.json to last-run.result.json

### DIFF
--- a/packages/cli/commands/run.ts
+++ b/packages/cli/commands/run.ts
@@ -1180,7 +1180,7 @@ export async function runCommand(
   }
 
   // ── Result JSON output ───────────────────────────────────────────────────
-  // Always write .glubean/last-run.json for tooling (VS Code, viewer).
+  // Always write .glubean/last-run.result.json for tooling (VS Code, viewer).
   // When --result-json is set, also write to the explicit/default path.
   const resultPayload = {
     target,
@@ -1208,7 +1208,7 @@ export async function runCommand(
   try {
     const glubeanDir = resolve(rootDir, ".glubean");
     await Deno.mkdir(glubeanDir, { recursive: true });
-    await Deno.writeTextFile(resolve(glubeanDir, "last-run.json"), resultJson);
+    await Deno.writeTextFile(resolve(glubeanDir, "last-run.result.json"), resultJson);
   } catch {
     // Non-critical
   }


### PR DESCRIPTION
## Summary

Renames `.glubean/last-run.json` → `.glubean/last-run.result.json`.

Because the VS Code extension registers `ResultViewerProvider` as a custom editor for `*.result.json`, the new filename is picked up automatically — no extra path-resolution logic needed in the Tasks Panel implementation.

## Test plan

- All 68 existing CLI tests pass
- `glubean run` now writes `.glubean/last-run.result.json` instead of `.glubean/last-run.json`

Made with [Cursor](https://cursor.com)