### PR TITLE
chore(cli): bump to 0.11.7 to publish last-run.result.json rename

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
## Summary

PR #24 renamed `.glubean/last-run.json` → `.glubean/last-run.result.json` but did not bump the version. The `auto-patch` workflow tried to re-publish `0.11.6` which was already on JSR and failed silently.

This PR bumps `@glubean/cli` to `0.11.7` so the rename is actually published.

## Test plan

- 68 existing CLI tests pass
- `auto-patch` workflow will publish `@glubean/cli@0.11.7`

Made with [Cursor](https://cursor.com)