### PR TITLE
chore(cli): add test tasks to minimal template, use glubean CLI directly

### DIFF
--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -397,6 +397,9 @@ const MINIMAL_DENO_JSON = `{
     "@glubean/sdk": "${SDK_IMPORT}"
   },
   "tasks": {
+    "test": "glubean run",
+    "test:verbose": "glubean run --verbose",
+    "test:ci": "glubean run --ci --result-json",
     "explore": "glubean run --explore --verbose",
     "scan": "glubean scan"
   },
@@ -404,6 +407,7 @@ const MINIMAL_DENO_JSON = `{
     "run": {
       "verbose": true,
       "pretty": true,
+      "testDir": "./tests",
       "exploreDir": "./explore"
     }
   }

--- a/packages/cli/templates/README.md
+++ b/packages/cli/templates/README.md
@@ -87,7 +87,7 @@ glubean run --env-file .env.production
 Or add a task in `deno.json`:
 
 ```json
-"test:production": "deno run -A jsr:@glubean/cli run --env-file .env.production"
+"test:production": "glubean run --env-file .env.production"
 ```
 
 All `*.secrets` files are gitignored by default. The non-secret `.env.*` files can be committed safely — they typically

--- a/packages/cli/templates/minimal-search.test.ts.tpl
+++ b/packages/cli/templates/minimal-search.test.ts.tpl
@@ -6,8 +6,8 @@
  * click a specific example to run.
  *
  * Run all:      deno task explore
- * Pick one:     deno run -A jsr:@glubean/cli run explore/search.test.ts --pick by-name
- * Pick another: deno run -A jsr:@glubean/cli run explore/search.test.ts --pick no-results
+ * Pick one:     glubean run explore/search.test.ts --pick by-name
+ * Pick another: glubean run explore/search.test.ts --pick no-results
  */
 import { test } from "@glubean/sdk";
 import examples from "../data/search-examples.json" with { type: "json" };


### PR DESCRIPTION
## Summary

- Add `test`, `test:verbose`, `test:ci` tasks to the minimal init template so new projects get CI-ready run presets out of the box.
- Make `testDir: "./tests"` explicit in the minimal glubean config.
- Replace all `deno run -A jsr:@glubean/cli run` references in templates with `glubean run` — users must install the CLI.

## Motivation

The minimal template is used for video demos and quick starts. It was missing test tasks that the VS Code Tasks Panel needs to display, and still had legacy `deno run jsr:...` invocations in comments/docs.

## Test plan

- [ ] `glubean init --minimal` scaffolds `deno.json` with `test`, `test:verbose`, `test:ci`, `explore`, `scan` tasks
- [ ] `testDir: "./tests"` is present in the generated config
- [ ] No `deno run -A jsr:@glubean/cli` references remain in generated files


Made with [Cursor](https://cursor.com)