### PR TITLE
chore(cli): bump version to 0.11.8

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
Publish updated minimal templates (test tasks, explicit testDir, glubean CLI references).

Made with [Cursor](https://cursor.com)