### PR TITLE
fix(cli): update init test to expect new minimal template tasks

### DIFF
--- a/packages/cli/commands/init_test.ts
+++ b/packages/cli/commands/init_test.ts
@@ -556,12 +556,14 @@ Deno.test("init --minimal creates minimal files", async () => {
     assertEquals(await fileExists(join(dir, "tests/demo.test.ts")), false);
     assertEquals(await fileExists(join(dir, "AGENTS.md")), false);
 
-    // Verify deno.json has explore task but not test tasks
+    // Verify deno.json has explore and test tasks
     const denoJson = JSON.parse(
       await Deno.readTextFile(join(dir, "deno.json")),
     );
     assertEquals(typeof denoJson.tasks?.explore, "string");
-    assertEquals(denoJson.tasks?.test, undefined);
+    assertEquals(denoJson.tasks?.test, "glubean run");
+    assertEquals(denoJson.tasks?.["test:ci"], "glubean run --ci --result-json");
+    assertEquals(denoJson.glubean?.run?.testDir, "./tests");
 
     // Verify .env has DummyJSON
     const envContent = await Deno.readTextFile(join(dir, ".env"));


### PR DESCRIPTION
The test at init_test.ts:564 asserted that the minimal template has no `test` task. Now that we added test tasks in #26, update the assertion to match.

Made with [Cursor](https://cursor.com)