### PR TITLE
chore(cli): bump version to 0.11.9

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
Re-publish after test fix in #28. The 0.11.8 publish failed due to the init test not being updated.

Made with [Cursor](https://cursor.com)