### PR TITLE
feat(cli): add ci task to init template and scaffold tests/ in minimal init

### DIFF
--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -234,7 +234,7 @@ function makeDenoJson(_baseUrl: string): string {
           "test:verbose": "glubean run --verbose",
           "test:staging": "glubean run --env-file .env.staging",
           "test:log": "glubean run --log-file",
-          ci: "glubean run --ci --result-json",
+          "test:ci": "glubean run --ci --result-json",
           explore: "glubean run --explore",
           "explore:verbose": "glubean run --explore --verbose",
           scan: "glubean scan",

--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -234,6 +234,7 @@ function makeDenoJson(_baseUrl: string): string {
           "test:verbose": "glubean run --verbose",
           "test:staging": "glubean run --env-file .env.staging",
           "test:log": "glubean run --log-file",
+          ci: "glubean run --ci --result-json",
           explore: "glubean run --explore",
           "explore:verbose": "glubean run --explore --verbose",
           scan: "glubean scan",
@@ -889,6 +890,11 @@ async function initMinimal(overwrite: boolean): Promise<void> {
       path: "README.md",
       content: () => readCliTemplate("minimal/README.md"),
       description: "Project README",
+    },
+    {
+      path: "tests/demo.test.ts",
+      content: () => readCliTemplate("demo.test.ts.tpl"),
+      description: "Demo tests (GET, POST, auth flow, pagination)",
     },
     {
       path: "explore/api.test.ts",

--- a/packages/cli/commands/init_test.ts
+++ b/packages/cli/commands/init_test.ts
@@ -596,8 +596,8 @@ Deno.test("init interactive - choose minimal", async () => {
       true,
     );
 
-    // Standard test files should NOT exist
-    assertEquals(await fileExists(join(dir, "tests/demo.test.ts")), false);
+    // Minimal now scaffolds tests/demo.test.ts
+    assertEquals(await fileExists(join(dir, "tests/demo.test.ts")), true);
 
     const envContent = await Deno.readTextFile(join(dir, ".env"));
     assertEquals(envContent.includes("dummyjson.com"), true);

--- a/packages/cli/commands/init_test.ts
+++ b/packages/cli/commands/init_test.ts
@@ -552,8 +552,8 @@ Deno.test("init --minimal creates minimal files", async () => {
       true,
     );
 
-    // Standard test files should NOT exist
-    assertEquals(await fileExists(join(dir, "tests/demo.test.ts")), false);
+    // tests/ has demo but no standard-only files
+    assertEquals(await fileExists(join(dir, "tests/demo.test.ts")), true);
     assertEquals(await fileExists(join(dir, "AGENTS.md")), false);
 
     // Verify deno.json has explore and test tasks

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
## Summary

- Add `ci: "glubean run --ci --result-json"` to the standard `makeDenoJson()` tasks (was already in `MINIMAL_DENO_JSON` but missing from the standard template)
- Scaffold `tests/demo.test.ts` in minimal init so the `tests/` directory exists with a working example out of the box (previously minimal init only created `explore/` files, leaving `tests/` empty despite `testDir: "./tests"` in config)
- Bump CLI version to `0.11.10`

**Cross-repo:** Companion VSCode PR at https://github.com/glubean/vscode/pull/new/fix/task-panel-completion

## Test plan

- [ ] `deno test packages/cli/commands/init_test.ts` passes
- [ ] Run `glubean init` (standard) — verify `ci` task appears in generated `deno.json`
- [ ] Run `glubean init --minimal` — verify `tests/demo.test.ts` is created


Made with [Cursor](https://cursor.com)