### PR TITLE
chore(cli): bump version to 0.11.11

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
## Summary

- Bump CLI version from 0.11.10 → 0.11.11 so `auto-patch` publishes the `writeEmptyResult` fix (merged in #32) to JSR.

The code change landed on main via #32 but the version stayed at 0.11.10 (already published), so it was never released.

Made with [Cursor](https://cursor.com)