### PR TITLE
fix(cli): exit 0 when no test files found

### DIFF
--- a/packages/cli/commands/run.ts
+++ b/packages/cli/commands/run.ts
@@ -402,7 +402,7 @@ export async function runCommand(
       `${colors.dim}Make sure *.test.ts files import from @glubean/sdk${colors.reset}\n`,
     );
     await writeEmptyResult(target, runStartLocal);
-    Deno.exit(1);
+    return;
   }
 
   if (isMultiFile) {

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
## Summary

- Change `Deno.exit(1)` → `return` when no test files are found
- Bump CLI version to 0.11.12

"No tests found" is not a failure — the CLI ran correctly, printed a warning, and wrote the result file with `total: 0`. Exiting 0 avoids VS Code's "failed to launch (exit code: 1)" terminal message when running from the task panel.

Companion PR: glubean/vscode (fix Learn more link + bump to 0.11.6)

Made with [Cursor](https://cursor.com)