### PR TITLE
feat(cli): add staging env files to minimal init template

### DIFF
--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -400,6 +400,7 @@ const MINIMAL_DENO_JSON = `{
   "tasks": {
     "test": "glubean run",
     "test:verbose": "glubean run --verbose",
+    "test:staging": "glubean run --env-file .env.staging",
     "test:ci": "glubean run --ci --result-json",
     "explore": "glubean run --explore --verbose",
     "scan": "glubean scan"
@@ -416,6 +417,8 @@ const MINIMAL_DENO_JSON = `{
 `;
 
 const MINIMAL_ENV = `# Environment variables
+# Tip: switch environments from the VS Code status bar — one click to toggle
+# between default, staging, and any custom .env.* file.
 BASE_URL=https://dummyjson.com
 `;
 
@@ -423,6 +426,19 @@ const MINIMAL_ENV_SECRETS = `# Secrets (add this file to .gitignore)
 # DummyJSON test credentials (public, safe to use)
 USERNAME=emilys
 PASSWORD=emilyspass
+`;
+
+const MINIMAL_ENV_STAGING = `# Staging environment variables
+# Usage: glubean run --env-file .env.staging
+# Tip: or switch to "staging" from the VS Code status bar — no CLI flags needed.
+BASE_URL=https://staging.dummyjson.com
+`;
+
+const MINIMAL_ENV_STAGING_SECRETS = `# Staging secrets (gitignored)
+# Usage: auto-loaded when --env-file .env.staging is used
+# API_KEY=your-staging-api-key
+USERNAME=
+PASSWORD=
 `;
 
 // ---------------------------------------------------------------------------
@@ -880,6 +896,16 @@ async function initMinimal(overwrite: boolean): Promise<void> {
       path: ".env.secrets",
       content: MINIMAL_ENV_SECRETS,
       description: "Secret variables (placeholder)",
+    },
+    {
+      path: ".env.staging",
+      content: MINIMAL_ENV_STAGING,
+      description: "Staging environment variables",
+    },
+    {
+      path: ".env.staging.secrets",
+      content: MINIMAL_ENV_STAGING_SECRETS,
+      description: "Staging secret variables",
     },
     {
       path: ".gitignore",

--- a/packages/cli/commands/init_test.ts
+++ b/packages/cli/commands/init_test.ts
@@ -556,12 +556,17 @@ Deno.test("init --minimal creates minimal files", async () => {
     assertEquals(await fileExists(join(dir, "tests/demo.test.ts")), true);
     assertEquals(await fileExists(join(dir, "AGENTS.md")), false);
 
+    // Staging env files
+    assertEquals(await fileExists(join(dir, ".env.staging")), true);
+    assertEquals(await fileExists(join(dir, ".env.staging.secrets")), true);
+
     // Verify deno.json has explore and test tasks
     const denoJson = JSON.parse(
       await Deno.readTextFile(join(dir, "deno.json")),
     );
     assertEquals(typeof denoJson.tasks?.explore, "string");
     assertEquals(denoJson.tasks?.test, "glubean run");
+    assertEquals(denoJson.tasks?.["test:staging"], "glubean run --env-file .env.staging");
     assertEquals(denoJson.tasks?.["test:ci"], "glubean run --ci --result-json");
     assertEquals(denoJson.glubean?.run?.testDir, "./tests");
 

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
## Summary

- Add `.env.staging` and `.env.staging.secrets` to minimal init scaffold (matching the standard template)
- Add `test:staging` task to `MINIMAL_DENO_JSON`
- Add comments in `.env` and `.env.staging` about one-click environment switching from the VS Code status bar
- Bump CLI to 0.11.13

Made with [Cursor](https://cursor.com)