### PR TITLE
docs(sdk,cli): guide AI to use ctx.secrets for credentials

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -216,8 +216,9 @@ const res = await ctx.http.post(`${baseUrl}/users`, {
 
 ## Other ctx APIs
 
-- `ctx.vars.get(key)` / `ctx.vars.require(key)` — environment variables
-- `ctx.secrets.get(key)` / `ctx.secrets.require(key)` — secret values
+- `ctx.vars.get(key)` / `ctx.vars.require(key)` — non-sensitive config (URLs, ports, regions)
+- `ctx.secrets.get(key)` / `ctx.secrets.require(key)` — credentials (API keys, tokens, passwords). **Always use secrets
+  for sensitive values** — they are auto-redacted in traces and never appear in logs.
 - `ctx.fail(message)` — immediately abort test
 - `ctx.skip(reason)` — skip test
 - `ctx.log(message)` — structured log

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -190,6 +190,9 @@ Every test function receives a `TestContext` with these capabilities:
 
 #### Environment Variables
 
+Use `ctx.vars` for non-sensitive configuration (URLs, ports, regions, feature flags). **For credentials (API keys,
+tokens, passwords), use `ctx.secrets` instead** — see [Secrets](#secrets) below.
+
 ```typescript
 // Safe access with explicit error handling
 const baseUrl = ctx.vars.require("BASE_URL"); // Throws if missing
@@ -200,7 +203,7 @@ const allVars = ctx.vars.all(); // Get all vars (for debugging)
 const port = ctx.vars.require("PORT", (v) => !isNaN(Number(v)));
 
 // With custom error message
-const apiKey = ctx.vars.require("API_KEY", (v) => v.length >= 32 ? true : `must be at least 32 chars, got ${v.length}`);
+const endpoint = ctx.vars.require("CALLBACK_URL", (v) => v.startsWith("https://") ? true : "must start with https://");
 ```
 
 #### Secrets

--- a/packages/sdk/deno.json
+++ b/packages/sdk/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/sdk",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts",

--- a/packages/sdk/types.ts
+++ b/packages/sdk/types.ts
@@ -8,10 +8,10 @@
  * @example
  * ```ts
  * try {
- *   const apiKey = ctx.vars.require("API_KEY");
+ *   const baseUrl = ctx.vars.require("BASE_URL");
  * } catch (err) {
  *   if (err instanceof GlubeanValidationError) {
- *     console.log(err.key);   // "API_KEY"
+ *     console.log(err.key);   // "BASE_URL"
  *     console.log(err.type);  // "var"
  *   }
  * }
@@ -76,6 +76,11 @@ export type ValidatorFn = (value: string) => boolean | string | void | null;
 
 /**
  * Provides safe access to environment variables for a test run.
+ * Use for non-sensitive configuration such as URLs, ports, regions, and feature flags.
+ *
+ * **For credentials (API keys, tokens, passwords), use {@link SecretsAccessor | ctx.secrets} instead.**
+ * Secrets are loaded from `.secrets` files, automatically redacted in traces, and never
+ * appear in logs or dashboards.
  *
  * Use `require` when a value must exist to avoid silent failures.
  *
@@ -106,8 +111,8 @@ export interface VarsAccessor {
    * const port = ctx.vars.require("PORT", (v) => !isNaN(Number(v)));
    *
    * @example With custom error message
-   * const key = ctx.vars.require("API_KEY", (v) =>
-   *   v.length >= 32 ? true : `must be at least 32 chars, got ${v.length}`
+   * const endpoint = ctx.vars.require("CALLBACK_URL", (v) =>
+   *   v.startsWith("https://") ? true : "must start with https://"
    * );
    */
   require(key: string, validate?: ValidatorFn): string;


### PR DESCRIPTION
## Summary

- **VarsAccessor JSDoc** now warns that credentials belong in `ctx.secrets`, not `ctx.vars`
- All `API_KEY` examples in vars documentation replaced with non-sensitive examples (`BASE_URL`, `CALLBACK_URL`)
- **SDK README** adds guidance paragraph before vars code block
- **CLI template AGENTS.md** clarifies vars (config) vs secrets (credentials) with auto-redaction note
- Bump sdk `0.11.1` → `0.11.2`, cli `0.11.13` → `0.11.14`

## Why

AI assistants read JSDoc and template files to generate test code. The previous examples used `ctx.vars.require("API_KEY")`, causing AI to consistently place credentials in `.env` via `ctx.vars` instead of `.secrets` via `ctx.secrets`. This means tokens appear unredacted in traces and logs.

## Test plan

- [x] `deno fmt` passes
- [x] No export changes — downstream packages unaffected

Made with [Cursor](https://cursor.com)