### PR TITLE
docs(mcp): rewrite README with prerequisites, config, and extension context

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,55 +1,102 @@
-# Glubean MCP server (Cursor / AI agent loop)
+# Glubean MCP Server
 
-> **Early-stage / experimental** — This package is under active development and not yet intended for direct external
-> consumption. APIs may change without notice. Full documentation will be added once the interface stabilises.
+> **Early-stage / experimental** — APIs may change without notice.
 
-This package provides a **Model Context Protocol (MCP)** server that enables an AI agent to:
+This package provides a **Model Context Protocol (MCP)** server that gives AI agents (Cursor, Windsurf, etc.) the
+ability to discover, run, and debug Glubean API tests — closing the loop:
 
-- discover Glubean `test` exports in a file
-- run them locally and return **structured failures**
-- trigger and fetch remote runs via Glubean **Open Platform API**
+> AI writes checks → runs → sees structured failures → fixes → reruns. You review the diff.
 
-This is the “closed loop” that enables:
+## Prerequisites
 
-> AI writes checks → runs → sees facts → fixes → reruns (you review the diff).
+**Deno** and a **Glubean project** are required. The MCP server runs tests via the Glubean runner, which is a Deno
+module. Without an existing Glubean project (`deno.json`, `.env`, test files), every tool returns empty results or
+errors.
 
-## Run locally (stdio)
+If you use the [Glubean VS Code extension](https://marketplace.visualstudio.com/items?itemName=glubean.glubean), Deno is
+already present — the extension checks for it on activation. The MCP server is a natural companion to the extension: the
+extension gives you a visual runner and trace viewer, while the MCP server lets your AI agent participate in the same
+workflow programmatically.
 
-From repo root:
+| Component              | Role                                                  |
+| ---------------------- | ----------------------------------------------------- |
+| **Glubean Extension**  | Visual runner, trace viewer, debug with breakpoints   |
+| **Glubean MCP Server** | AI agent loop — discover, run, diagnose, fix          |
+| **Glubean CLI**        | CI/CD, headless execution, `glubean init` scaffolding |
 
-```bash
-deno run -A ./packages/mcp/mod.ts
+All three share the same SDK, runner, and project structure.
+
+## Configuration
+
+### Cursor
+
+Add to `.cursor/mcp.json` in your project root (or globally in `~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "glubean": {
+      "command": "deno",
+      "args": ["run", "-A", "jsr:@glubean/mcp"]
+    }
+  }
+}
 ```
 
-Notes:
+### VS Code (Copilot MCP)
 
-- This is a **stdio** MCP server. It must not write to stdout except MCP JSON-RPC.
-- The server uses stderr for logs.
-- Local execution uses the Glubean runner, which spawns a Deno subprocess. You need `-A` (or at least
-  `--allow-run --allow-read --allow-net`).
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "glubean": {
+      "type": "stdio",
+      "command": "deno",
+      "args": ["run", "-A", "jsr:@glubean/mcp"]
+    }
+  }
+}
+```
+
+### Windsurf / other MCP clients
+
+Any MCP client that supports stdio transport can use the same command:
+
+```bash
+deno run -A jsr:@glubean/mcp
+```
 
 ## Tools
 
-- `glubean_discover_tests`
-- `glubean_run_local_file`
-- `glubean_get_last_run_summary`
-- `glubean_get_local_events`
-- `glubean_list_test_files`
-- `glubean_diagnose_config`
-- `glubean_get_metadata`
-- `glubean_open_trigger_run`
-- `glubean_open_get_run`
-- `glubean_open_get_run_events`
+### Test discovery & execution
 
-### Local debugging helpers
+- `glubean_discover_tests` — list all `test` exports in a file
+- `glubean_run_local_file` — run tests locally and return structured results
+- `glubean_list_test_files` — find test files in the project
 
-- `glubean_get_last_run_summary`: Returns summary metadata for the most recent `glubean_run_local_file` call.
-- `glubean_get_local_events`: Returns flattened local events (`result`, `assertion`, `log`, `trace`) with optional
-  filtering.
-- `glubean_diagnose_config`: Checks project config health (`deno.json`, `.env`, `.env.secrets`, `tests/`, `explore/`)
-  and returns actionable recommendations.
+### Debugging & diagnostics
 
-## Security notes
+- `glubean_get_last_run_summary` — summary of the most recent local run
+- `glubean_get_local_events` — flattened events (`result`, `assertion`, `log`, `trace`) with optional filtering
+- `glubean_diagnose_config` — checks project health (`deno.json`, `.env`, `.env.secrets`, `tests/`, `explore/`) and
+  returns actionable recommendations
 
-- The MCP server never returns `.env.secrets` values.
+### Metadata & remote runs
+
+- `glubean_get_metadata` — project metadata (test count, tags, files)
+- `glubean_open_trigger_run` — trigger a remote run via Glubean Open Platform API
+- `glubean_open_get_run` — fetch remote run status
+- `glubean_open_get_run_events` — fetch remote run events
+
+## Notes
+
+- This is a **stdio** transport server. It must not write to stdout except MCP JSON-RPC messages.
+- The server uses stderr for debug logs.
+- Local execution spawns a Deno subprocess — the `-A` flag (or at least `--allow-run --allow-read --allow-net`) is
+  required.
+
+## Security
+
+- The MCP server **never returns `.env.secrets` values** in tool output. Secret values are redacted.
 - Remote run tools require a **project token** (Open Platform) with least-privilege scopes.


### PR DESCRIPTION
## Summary

- Add **Prerequisites** section: Deno + Glubean project are required, explain why
- Add **Configuration** section with copy-paste examples for Cursor, VS Code, and Windsurf
- Add component relationship table (Extension / MCP / CLI) to clarify the symbiotic role
- Reorganize tools into logical groups (discovery, debugging, remote)
- Clarify security notes


Made with [Cursor](https://cursor.com)