### PR TITLE
docs(sdk,cli): clarify ctx.http is ky wrapper, add form-urlencoded examples

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.14",
+  "version": "0.11.15",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",

--- a/packages/cli/templates/AGENTS.md
+++ b/packages/cli/templates/AGENTS.md
@@ -120,7 +120,8 @@ export const createUser = test.pick({
 
 ## ctx.http Quick Reference
 
-`ctx.http` is a pre-configured HTTP client (powered by ky) with auto-tracing:
+`ctx.http` is a **thin wrapper around [ky](https://github.com/sindresorhus/ky)** with auto-tracing. All ky options are
+supported. **There is no `form` shortcut** — use `body: new URLSearchParams(...)` for form data.
 
 ```typescript
 // GET with JSON parsing
@@ -130,6 +131,15 @@ const users = await ctx.http.get(`${baseUrl}/users`).json();
 const created = await ctx.http
   .post(`${baseUrl}/users`, { json: { name: "test" } })
   .json();
+
+// POST with form-urlencoded data (e.g. OAuth token requests)
+const tokenRes = await ctx.http.post(`${authUrl}/token`, {
+  body: new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: ctx.secrets.require("CLIENT_ID"),
+    client_secret: ctx.secrets.require("CLIENT_SECRET"),
+  }),
+});
 
 // Scoped client with shared config
 const api = ctx.http.extend({ prefixUrl: baseUrl });

--- a/packages/sdk/deno.json
+++ b/packages/sdk/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/sdk",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts",

--- a/packages/sdk/types.ts
+++ b/packages/sdk/types.ts
@@ -1013,11 +1013,35 @@ export interface HttpRetryOptions {
 
 /**
  * Options for HTTP requests.
- * Compatible with ky's Options interface.
  *
- * @example POST with JSON
+ * **`ctx.http` is a thin wrapper around [ky](https://github.com/sindresorhus/ky).**
+ * All ky options are supported. See https://github.com/sindresorhus/ky#options
+ * for the complete reference.
+ *
+ * **There is no `form` shortcut** — ky (and therefore `ctx.http`) does not have one.
+ * Use `body: new URLSearchParams(...)` for `application/x-www-form-urlencoded` data.
+ *
+ * @example POST with JSON (most common)
  * ```ts
- * ctx.http.post(url, { json: { name: "test" } });
+ * const res = await ctx.http.post(url, { json: { name: "test" } });
+ * ```
+ *
+ * @example POST with form-urlencoded data
+ * ```ts
+ * const res = await ctx.http.post(url, {
+ *   body: new URLSearchParams({
+ *     grant_type: "client_credentials",
+ *     client_id: ctx.secrets.require("CLIENT_ID"),
+ *     client_secret: ctx.secrets.require("CLIENT_SECRET"),
+ *   }),
+ * });
+ * ```
+ *
+ * @example POST with multipart form data
+ * ```ts
+ * const form = new FormData();
+ * form.append("file", new Blob(["content"]), "test.txt");
+ * const res = await ctx.http.post(url, { body: form });
  * ```
  *
  * @example With search params and timeout
@@ -1048,7 +1072,15 @@ export interface HttpRequestOptions {
   throwHttpErrors?: boolean;
   /** HTTP method override */
   method?: string;
-  /** Request body (for non-JSON payloads) */
+  /**
+   * Request body for non-JSON payloads.
+   *
+   * - `new URLSearchParams(...)` for `application/x-www-form-urlencoded`
+   * - `new FormData()` for `multipart/form-data`
+   * - `string` or `Blob` for raw payloads
+   *
+   * Do **not** use `json` and `body` together — `json` takes precedence.
+   */
   body?: BodyInit;
   /** AbortSignal for request cancellation */
   signal?: AbortSignal;


### PR DESCRIPTION
## Summary
- Rewrite `HttpRequestOptions` JSDoc: "Compatible with ky" → "This is a thin wrapper around ky" with doc link
- Add explicit warning: "There is no `form` shortcut"
- Add form-urlencoded, multipart FormData examples to JSDoc
- Enhance `body` field docs with all payload types
- Update CLI template AGENTS.md with form-urlencoded OAuth example

Fixes AI generating `{ form: {...} }` which doesn't exist in ky.

## Test plan
- [x] `deno fmt --check` passes
- [x] `deno check packages/*/mod.ts` passes
- [x] `deno check packages/*/*.ts` passes
- [x] Docs-only + version bumps (SDK 0.11.5, CLI 0.11.15)

Made with [Cursor](https://cursor.com)