### PR TITLE
test(mcp): add integration tests for core functions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,8 @@
   ],
   "test": {
     "exclude": [
-      "packages/cli/templates/"
+      "packages/cli/templates/",
+      "packages/mcp/testdata/"
     ]
   },
   "workspace": [

--- a/packages/mcp/deno.json
+++ b/packages/mcp/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/mcp",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean MCP server - run checks and fetch facts for AI agents",

--- a/packages/mcp/integration_test.ts
+++ b/packages/mcp/integration_test.ts
@@ -1,0 +1,163 @@
+import { assertEquals } from "@std/assert";
+import { resolve } from "@std/path";
+import {
+  deriveSecretsPath,
+  diagnoseProjectConfig,
+  discoverTestsFromFile,
+  findProjectRoot,
+  loadEnvFile,
+  runLocalTestsFromFile,
+} from "./mod.ts";
+
+const FIXTURE_DIR = resolve(
+  new URL(".", import.meta.url).pathname,
+  "testdata",
+  "simple-project",
+);
+
+// ---------------------------------------------------------------------------
+// Layer 1a: Pure helper unit tests
+// ---------------------------------------------------------------------------
+
+Deno.test("findProjectRoot walks up to deno.json", async () => {
+  const testsDir = resolve(FIXTURE_DIR, "tests");
+  const root = await findProjectRoot(testsDir);
+  assertEquals(root, FIXTURE_DIR);
+});
+
+Deno.test("findProjectRoot returns startDir when no deno.json found", async () => {
+  const tmpDir = await Deno.makeTempDir({ prefix: "mcp-no-root-" });
+  try {
+    const root = await findProjectRoot(tmpDir);
+    assertEquals(root, tmpDir);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
+});
+
+Deno.test("deriveSecretsPath follows .env → .env.secrets convention", () => {
+  assertEquals(deriveSecretsPath("/project/.env"), "/project/.env.secrets");
+});
+
+Deno.test("deriveSecretsPath handles named env files", () => {
+  assertEquals(
+    deriveSecretsPath("/project/.env.staging"),
+    "/project/.env.staging.secrets",
+  );
+});
+
+Deno.test("deriveSecretsPath resolves relative paths", () => {
+  const result = deriveSecretsPath("subdir/.env");
+  assertEquals(result.endsWith(".env.secrets"), true);
+  assertEquals(result.includes("subdir"), true);
+});
+
+Deno.test("loadEnvFile parses dotenv content", async () => {
+  const envPath = resolve(FIXTURE_DIR, ".env");
+  const vars = await loadEnvFile(envPath);
+  assertEquals(vars["BASE_URL"], "https://httpbin.org");
+});
+
+Deno.test("loadEnvFile returns empty object for missing file", async () => {
+  const vars = await loadEnvFile("/nonexistent/.env.nope");
+  assertEquals(vars, {});
+});
+
+Deno.test("loadEnvFile parses secrets file", async () => {
+  const secretsPath = resolve(FIXTURE_DIR, ".env.secrets");
+  const secrets = await loadEnvFile(secretsPath);
+  assertEquals(secrets["DUMMY_SECRET"], "test-value");
+});
+
+// ---------------------------------------------------------------------------
+// Layer 1b: discoverTestsFromFile (dynamic import, no subprocess)
+// ---------------------------------------------------------------------------
+
+Deno.test("discoverTestsFromFile finds exported tests", async () => {
+  const filePath = resolve(FIXTURE_DIR, "tests", "health.test.ts");
+  const { tests, fileUrl } = await discoverTestsFromFile(filePath);
+
+  assertEquals(fileUrl.startsWith("file://"), true);
+  assertEquals(tests.length, 1);
+  assertEquals(tests[0].id, "health-check");
+  assertEquals(tests[0].exportName, "healthCheck");
+});
+
+Deno.test("discoverTestsFromFile finds failing test fixture", async () => {
+  const filePath = resolve(FIXTURE_DIR, "tests", "failing.test.ts");
+  const { tests } = await discoverTestsFromFile(filePath);
+
+  assertEquals(tests.length, 1);
+  assertEquals(tests[0].id, "always-fails");
+});
+
+// ---------------------------------------------------------------------------
+// Layer 1c: runLocalTestsFromFile (spawns subprocess via TestExecutor)
+// ---------------------------------------------------------------------------
+
+Deno.test("runLocalTestsFromFile executes passing test", async () => {
+  const filePath = resolve(FIXTURE_DIR, "tests", "health.test.ts");
+  const result = await runLocalTestsFromFile({ filePath });
+
+  assertEquals(result.summary.total, 1);
+  assertEquals(result.summary.passed, 1);
+  assertEquals(result.summary.failed, 0);
+  assertEquals(result.results.length, 1);
+  assertEquals(result.results[0].success, true);
+  assertEquals(result.results[0].id, "health-check");
+
+  const passedAssertions = result.results[0].assertions.filter((a: { passed: boolean }) => a.passed);
+  assertEquals(passedAssertions.length > 0, true);
+});
+
+Deno.test("runLocalTestsFromFile loads env vars from fixture", async () => {
+  const filePath = resolve(FIXTURE_DIR, "tests", "health.test.ts");
+  const result = await runLocalTestsFromFile({ filePath });
+
+  assertEquals(result.vars["BASE_URL"], "https://httpbin.org");
+  assertEquals(result.secrets["DUMMY_SECRET"], "test-value");
+  assertEquals(result.projectRoot, FIXTURE_DIR);
+});
+
+Deno.test("runLocalTestsFromFile reports failure correctly", async () => {
+  const filePath = resolve(FIXTURE_DIR, "tests", "failing.test.ts");
+  const result = await runLocalTestsFromFile({ filePath });
+
+  assertEquals(result.summary.total, 1);
+  assertEquals(result.summary.passed, 0);
+  assertEquals(result.summary.failed, 1);
+  assertEquals(result.results[0].success, false);
+
+  const failedAssertions = result.results[0].assertions.filter((a: { passed: boolean }) => !a.passed);
+  assertEquals(failedAssertions.length > 0, true);
+});
+
+Deno.test("runLocalTestsFromFile returns error for non-matching filter", async () => {
+  const filePath = resolve(FIXTURE_DIR, "tests", "health.test.ts");
+  const result = await runLocalTestsFromFile({
+    filePath,
+    filter: "nonexistent-filter",
+  });
+
+  assertEquals(result.results.length, 0);
+  assertEquals(result.summary.total, 0);
+  assertEquals(typeof result.error, "string");
+});
+
+// ---------------------------------------------------------------------------
+// Layer 1d: diagnoseProjectConfig with real fixture
+// ---------------------------------------------------------------------------
+
+Deno.test("diagnoseProjectConfig detects fixture project structure", async () => {
+  const diagnostics = await diagnoseProjectConfig({ dir: FIXTURE_DIR });
+
+  assertEquals(diagnostics.projectRoot, FIXTURE_DIR);
+  assertEquals(diagnostics.denoJson.exists, true);
+  assertEquals(diagnostics.envFile.exists, true);
+  assertEquals(diagnostics.envFile.hasBaseUrl, true);
+  assertEquals(diagnostics.envFile.varCount, 1);
+  assertEquals(diagnostics.secretsFile.exists, true);
+  assertEquals(diagnostics.secretsFile.secretCount, 1);
+  assertEquals(diagnostics.testsDir.exists, true);
+  assertEquals(diagnostics.recommendations.length, 0);
+});

--- a/packages/mcp/mod.ts
+++ b/packages/mcp/mod.ts
@@ -26,7 +26,7 @@ import { DEFAULT_GENERATED_BY, MCP_PACKAGE_VERSION } from "./version.ts";
 type Vars = Record<string, string>;
 const METADATA_SCHEMA_VERSION = "1";
 
-async function findProjectRoot(startDir: string): Promise<string> {
+export async function findProjectRoot(startDir: string): Promise<string> {
   let dir = startDir;
   while (true) {
     try {
@@ -41,7 +41,7 @@ async function findProjectRoot(startDir: string): Promise<string> {
   return startDir;
 }
 
-async function loadEnvFile(envPath: string): Promise<Vars> {
+export async function loadEnvFile(envPath: string): Promise<Vars> {
   try {
     const content = await Deno.readTextFile(envPath);
     return parse(content);
@@ -55,7 +55,7 @@ async function loadEnvFile(envPath: string): Promise<Vars> {
  * Convention: `.env` → `.env.secrets`, `.env.staging` → `.env.staging.secrets`.
  * Mirrors the logic in `packages/cli/commands/run.ts`.
  */
-function deriveSecretsPath(envPath: string): string {
+export function deriveSecretsPath(envPath: string): string {
   return resolve(dirname(envPath), `${basename(envPath)}.secrets`);
 }
 
@@ -137,7 +137,7 @@ async function buildMetadata(
   };
 }
 
-async function discoverTestsFromFile(filePath: string): Promise<{
+export async function discoverTestsFromFile(filePath: string): Promise<{
   fileUrl: string;
   tests: ResolvedTest[];
 }> {
@@ -378,7 +378,7 @@ export async function diagnoseProjectConfig(args: {
   };
 }
 
-async function runLocalTestsFromFile(args: {
+export async function runLocalTestsFromFile(args: {
   filePath: string;
   filter?: string;
   envFile?: string;

--- a/packages/mcp/testdata/simple-project/deno.json
+++ b/packages/mcp/testdata/simple-project/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@glubean/sdk": "jsr:@glubean/sdk@^0.11.0"
+  }
+}

--- a/packages/mcp/testdata/simple-project/tests/failing.test.ts
+++ b/packages/mcp/testdata/simple-project/tests/failing.test.ts
@@ -1,0 +1,8 @@
+import { test } from "@glubean/sdk";
+
+export const failingTest = test(
+  "always-fails",
+  async (ctx) => {
+    ctx.assert(false, "this should fail");
+  },
+);

--- a/packages/mcp/testdata/simple-project/tests/health.test.ts
+++ b/packages/mcp/testdata/simple-project/tests/health.test.ts
@@ -1,0 +1,9 @@
+import { test } from "@glubean/sdk";
+
+export const healthCheck = test(
+  "health-check",
+  async (ctx) => {
+    ctx.assert(true, "always passes");
+    ctx.log("health check executed");
+  },
+);


### PR DESCRIPTION
## Summary
- Export 5 core functions from `mod.ts` for testability
- Add `testdata/simple-project/` fixture with passing and failing tests
- 15 new integration tests covering helpers, discovery, execution, and diagnostics
- Bump MCP version 0.11.1 → 0.11.2

## Test plan
- [x] `deno test -A packages/mcp/` — 22 passed (15 new + 7 existing)
- [x] `deno fmt --check` passes
- [x] `deno check packages/*/*.ts` passes

Made with [Cursor](https://cursor.com)