### PR TITLE
chore: bump all packages to ensure JSR publication

### DIFF
--- a/packages/auth/deno.json
+++ b/packages/auth/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/auth",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",

--- a/packages/graphql/deno.json
+++ b/packages/graphql/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/graphql",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts"

--- a/packages/mcp/deno.json
+++ b/packages/mcp/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/mcp",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean MCP server - run checks and fetch facts for AI agents",

--- a/packages/redaction/deno.json
+++ b/packages/redaction/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/redaction",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Redaction Engine - Plugin-based secrets/PII detection and masking",

--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/runner",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Runner - Test executor with sandboxed Deno subprocess",

--- a/packages/scanner/deno.json
+++ b/packages/scanner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/scanner",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "exports": {
     ".": "./mod.ts",
     "./static": "./static.ts"

--- a/packages/sdk/deno.json
+++ b/packages/sdk/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/sdk",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts",

--- a/packages/worker/deno.json
+++ b/packages/worker/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/worker",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "exports": {
     ".": "./mod.ts",
     "./cli": "./cli.ts"


### PR DESCRIPTION
## Summary

- Patch bump all 9 packages to trigger the `auto-patch` workflow and verify every package publishes correctly to JSR
- `mcp` was behind (0.11.2 local vs 0.11.1 on JSR); the rest are bumped for consistency

| Package | Before | After |
|---|---|---|
| sdk | 0.11.5 | 0.11.6 |
| runner | 0.11.2 | 0.11.3 |
| scanner | 0.11.1 | 0.11.2 |
| cli | 0.11.15 | 0.11.16 |
| mcp | 0.11.2 | 0.11.3 |
| redaction | 0.11.0 | 0.11.1 |
| auth | 0.11.0 | 0.11.1 |
| graphql | 0.11.0 | 0.11.1 |
| worker | 0.11.0 | 0.11.1 |

## Test plan

- [x] `deno check packages/*/*.ts` passes
- [ ] `auto-patch` workflow publishes all packages to JSR after merge