### PR TITLE
docs(cli): document CLI_VERSION export for JSR symbol docs

### DIFF
--- a/packages/cli/version.ts
+++ b/packages/cli/version.ts
@@ -1,3 +1,13 @@
 import denoConfig from "./deno.json" with { type: "json" };
 
+/**
+ * Current Glubean CLI version from this package's `deno.json`.
+ *
+ * Exposed for tooling and diagnostics that need to print or compare
+ * the installed CLI version at runtime.
+ *
+ * @example
+ * import { CLI_VERSION } from "@glubean/cli";
+ * console.log(`glubean ${CLI_VERSION}`);
+ */
 export const CLI_VERSION: string = denoConfig.version;


### PR DESCRIPTION
## Summary
- add JSDoc to `CLI_VERSION` in `packages/cli/version.ts`
- ensure the CLI package has symbol-level API documentation for JSR score calculation
- keep runtime behavior unchanged

## Test plan
- [x] inspect diff to confirm only documentation comment was added
- [x] run lints for edited file in editor diagnostics

Made with [Cursor](https://cursor.com)