### PR TITLE
chore(cli): bump @glubean/cli to 0.11.17

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
## Summary
- bump `@glubean/cli` version in `packages/cli/deno.json` from `0.11.16` to `0.11.17`
- prepare a publishable patch release for the previously merged CLI symbol-docs fix

## Test plan
- [x] verify only version field changed

Made with [Cursor](https://cursor.com)