### PR TITLE
fix(mcp): track fixture env files for integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .env.secrets
 .env.*.secrets
 .env.*.local
+!packages/mcp/testdata/simple-project/.env
+!packages/mcp/testdata/simple-project/.env.secrets
 
 # Test logs
 *.log

--- a/packages/mcp/testdata/simple-project/.env
+++ b/packages/mcp/testdata/simple-project/.env
@@ -1,0 +1,1 @@
+BASE_URL=https://httpbin.org

--- a/packages/mcp/testdata/simple-project/.env.secrets
+++ b/packages/mcp/testdata/simple-project/.env.secrets
@@ -1,0 +1,1 @@
+DUMMY_SECRET=test-value


### PR DESCRIPTION
## Summary
- unignore MCP fixture env files used by integration tests
- commit `packages/mcp/testdata/simple-project/.env`
- commit `packages/mcp/testdata/simple-project/.env.secrets`

## Test plan
- [x] deno test -A packages/mcp/integration_test.ts

Made with [Cursor](https://cursor.com)