### PR TITLE
fix(mcp): remove unnecessary async from fixture tests

### DIFF
--- a/packages/mcp/testdata/simple-project/tests/failing.test.ts
+++ b/packages/mcp/testdata/simple-project/tests/failing.test.ts
@@ -2,7 +2,7 @@ import { test } from "@glubean/sdk";
 
 export const failingTest = test(
   "always-fails",
-  async (ctx) => {
+  (ctx) => {
     ctx.assert(false, "this should fail");
   },
 );

--- a/packages/mcp/testdata/simple-project/tests/health.test.ts
+++ b/packages/mcp/testdata/simple-project/tests/health.test.ts
@@ -2,7 +2,7 @@ import { test } from "@glubean/sdk";
 
 export const healthCheck = test(
   "health-check",
-  async (ctx) => {
+  (ctx) => {
     ctx.assert(true, "always passes");
     ctx.log("health check executed");
   },


### PR DESCRIPTION
## Summary
- remove unnecessary `async` from MCP fixture test callbacks
- satisfy `deno lint` rule `require-await` in fixture test files
- keep fixture behavior unchanged

## Test plan
- [x] deno lint

Made with [Cursor](https://cursor.com)