### PR TITLE
feat(sdk): add plugin-level activation rules

### DIFF
--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/runner",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Runner - Test executor with sandboxed Deno subprocess",

--- a/packages/runner/executor.ts
+++ b/packages/runner/executor.ts
@@ -128,6 +128,14 @@ export interface ExecutionNetworkPolicy {
 export interface ExecutionContext {
   vars: Record<string, string>;
   secrets: Record<string, string>;
+  /**
+   * Metadata for the currently executing test.
+   * Passed through to the harness runtime for plugin activation decisions.
+   */
+  test?: {
+    id?: string;
+    tags?: string[];
+  };
   /** Whole-test re-run count for this execution (0 for first attempt). */
   retryCount?: number;
   /** Optional egress policy applied by the harness runtime. */
@@ -577,9 +585,16 @@ export class TestExecutor {
 
     // Write context to stdin
     try {
+      const normalizedContext: ExecutionContext = {
+        ...context,
+        test: {
+          id: context.test?.id ?? testId,
+          tags: context.test?.tags ?? [],
+        },
+      };
       const encoder = new TextEncoder();
       const writer = process.stdin.getWriter();
-      await writer.write(encoder.encode(JSON.stringify(context)));
+      await writer.write(encoder.encode(JSON.stringify(normalizedContext)));
       await writer.close();
     } catch (error) {
       // If stdin write fails, kill the process and propagate error

--- a/packages/runner/harness.ts
+++ b/packages/runner/harness.ts
@@ -125,6 +125,27 @@ const rawSecrets = (contextData.secrets ?? {}) as Record<string, string>;
 // 0 => first execution attempt.
 const retryCount = (contextData.retryCount ?? 0) as number;
 
+function normalizeTestTags(
+  input: string | string[] | undefined,
+): string[] {
+  if (!input) return [];
+  if (Array.isArray(input)) return input.filter((tag): tag is string => typeof tag === "string");
+  return [input];
+}
+
+function parseRuntimeTestMetadata(
+  input: unknown,
+): { id: string; tags: string[] } {
+  const candidate = input && typeof input === "object" ? (input as { id?: unknown; tags?: unknown }) : undefined;
+  const id = typeof candidate?.id === "string" ? candidate.id : (testId ?? "");
+  const tags = Array.isArray(candidate?.tags)
+    ? candidate.tags.filter((tag): tag is string => typeof tag === "string")
+    : [];
+  return { id, tags };
+}
+
+const runtimeTest = parseRuntimeTestMetadata(contextData.test);
+
 interface SharedServerlessNetworkPolicy {
   mode: "shared_serverless";
   maxRequests: number;
@@ -1259,6 +1280,7 @@ function withEnvFallback(
   secrets: withEnvFallback(rawSecrets),
   // deno-lint-ignore no-explicit-any
   http: (ctx as any).http,
+  test: runtimeTest,
 };
 
 try {
@@ -1420,12 +1442,19 @@ async function withFixtures(
  * @param test The Test object to execute
  */
 async function executeNewTest(test: Test<unknown>): Promise<void> {
+  const testTags = normalizeTestTags(test.meta.tags);
+  // Keep runtime metadata aligned with the actual resolved test before user code runs.
+  // deno-lint-ignore no-explicit-any
+  (globalThis as any).__glubeanRuntime.test = {
+    id: test.meta.id,
+    tags: testTags,
+  };
   console.log(
     JSON.stringify({
       type: "start",
       id: test.meta.id,
       name: test.meta.name || test.meta.id,
-      tags: test.meta.tags,
+      tags: testTags,
       ...(retryCount > 0 && { retryCount }),
     }),
   );

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -170,6 +170,53 @@ export const { http, vars, secrets } = configure({
 All configured values are lazy and resolved at runtime, so they are safe at module top-level and safe for scanner
 imports.
 
+### Plugin activation
+
+Plugins support optional activation rules that control when the plugin is available. Plugin authors do not need to know
+about activation — it is entirely controlled by the caller.
+
+```typescript
+import { configure, definePlugin } from "@glubean/sdk";
+
+const secureApiPlugin = definePlugin((runtime) => {
+  const client = runtime.http.extend({
+    prefixUrl: runtime.requireVar("BASE_URL"),
+    headers: {
+      Authorization: `Bearer ${runtime.requireSecret("API_KEY")}`,
+    },
+  });
+
+  return {
+    getUsers: () => client.get("users").json(),
+    getInternalAudit: () => client.get("users/internal/audit").json(),
+  };
+});
+
+const { secureApi } = configure({
+  plugins: {
+    secureApi: {
+      factory: secureApiPlugin,
+      activation: {
+        tags: {
+          enable: ["auth"],
+          disable: ["no-auth"],
+        },
+        requests: {
+          include: [{ method: "GET", path: /^\/users/ }],
+          exclude: [{ path: /^\/users\/internal\// }],
+        },
+      },
+    },
+  },
+});
+```
+
+- `activation.tags.enable`: plugin is active only when at least one listed test tag matches
+- `activation.tags.disable`: plugin is inactive when any listed tag matches (higher priority than enable)
+- `activation.requests.include`: plugin HTTP calls are allowed only when request matches at least one rule
+- `activation.requests.exclude`: plugin HTTP calls are blocked when request matches any rule (higher priority than
+  include)
+
 Then use them in any test file:
 
 ```typescript

--- a/packages/sdk/configure.ts
+++ b/packages/sdk/configure.ts
@@ -57,7 +57,11 @@ import type {
   ConfigureResult,
   GlubeanRuntime,
   HttpClient,
+  HttpRequestOptions,
+  PluginActivation,
+  PluginEntry,
   PluginFactory,
+  RequestMatcher,
   ReservedConfigureKeys,
   ResolvePlugins,
 } from "./types.ts";
@@ -77,6 +81,7 @@ export interface InternalRuntime {
   vars: Record<string, string>;
   secrets: Record<string, string>;
   http: HttpClient;
+  test?: GlubeanRuntime["test"];
 }
 
 /**
@@ -316,37 +321,219 @@ function buildLazyHttp(httpOptions: ConfigureHttpOptions): HttpClient {
 /** Reserved keys that plugins cannot shadow. */
 const RESERVED_KEYS = new Set(["vars", "secrets", "http"]);
 
+function normalizePluginEntry<T>(
+  entry: PluginFactory<T> | PluginEntry<T>,
+): PluginEntry<T> {
+  if ("factory" in entry) return entry as PluginEntry<T>;
+  return { factory: entry as PluginFactory<T> };
+}
+
+function toMethodList(value?: string | string[]): string[] {
+  if (!value) return [];
+  const list = Array.isArray(value) ? value : [value];
+  return list.map((method) => method.toUpperCase());
+}
+
+function toUrlString(input: string | URL | Request): string {
+  if (input instanceof Request) return input.url;
+  if (input instanceof URL) return input.toString();
+  return input;
+}
+
+function toPathname(input: string | URL | Request): string {
+  try {
+    if (input instanceof Request) return new URL(input.url).pathname;
+    if (input instanceof URL) return input.pathname;
+    const isAbsolute = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(input);
+    const parsed = isAbsolute ? new URL(input) : new URL(input, "http://glubean.local");
+    return parsed.pathname;
+  } catch {
+    return "";
+  }
+}
+
+function matchesPattern(value: string, pattern: string | RegExp): boolean {
+  if (pattern instanceof RegExp) return pattern.test(value);
+  return value.startsWith(pattern);
+}
+
+function matchesRequestMatcher(
+  matcher: RequestMatcher,
+  method: string,
+  url: string | URL | Request,
+): boolean {
+  const methods = toMethodList(matcher.method);
+  if (methods.length > 0 && !methods.includes(method)) {
+    return false;
+  }
+
+  if (matcher.url) {
+    const rawUrl = toUrlString(url);
+    if (!matchesPattern(rawUrl, matcher.url)) {
+      return false;
+    }
+  }
+
+  if (matcher.path) {
+    const pathname = toPathname(url);
+    if (!matchesPattern(pathname, matcher.path)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function evaluateRequestActivation(
+  activation: PluginActivation | undefined,
+  method: string,
+  url: string | URL | Request,
+): { active: boolean; reason?: string } {
+  const rules = activation?.requests;
+  if (!rules) return { active: true };
+
+  const exclude = rules.exclude ?? [];
+  if (exclude.some((matcher) => matchesRequestMatcher(matcher, method, url))) {
+    return {
+      active: false,
+      reason: "request matches activation.requests.exclude",
+    };
+  }
+
+  const include = rules.include ?? [];
+  if (include.length > 0 && !include.some((matcher) => matchesRequestMatcher(matcher, method, url))) {
+    return {
+      active: false,
+      reason: "request does not match activation.requests.include",
+    };
+  }
+
+  return { active: true };
+}
+
+function evaluateTagActivation(
+  activation: PluginActivation | undefined,
+  runtime: InternalRuntime,
+): { active: boolean; reason?: string } {
+  const rules = activation?.tags;
+  if (!rules) return { active: true };
+
+  const runtimeTags = new Set(runtime.test?.tags ?? []);
+  const disable = rules.disable ?? [];
+  for (const tag of disable) {
+    if (runtimeTags.has(tag)) {
+      return {
+        active: false,
+        reason: `test tag "${tag}" matches activation.tags.disable`,
+      };
+    }
+  }
+
+  const enable = rules.enable ?? [];
+  if (enable.length > 0) {
+    const matched = enable.some((tag) => runtimeTags.has(tag));
+    if (!matched) {
+      return {
+        active: false,
+        reason: `current test tags do not match activation.tags.enable (${enable.join(", ")})`,
+      };
+    }
+  }
+
+  return { active: true };
+}
+
+function buildActivationAwareHttpClient(
+  pluginName: string,
+  activation: PluginActivation | undefined,
+  http: HttpClient,
+): HttpClient {
+  if (!activation?.requests) return http;
+
+  function assertRequestActive(
+    method: string,
+    url: string | URL | Request,
+  ): void {
+    const decision = evaluateRequestActivation(activation, method, url);
+    if (decision.active) return;
+    throw new Error(
+      `Plugin "${pluginName}" is inactive for request ${method} ${toUrlString(url)}: ${decision.reason}.`,
+    );
+  }
+
+  const METHODS = ["get", "post", "put", "patch", "delete", "head"] as const;
+  // deno-lint-ignore no-explicit-any
+  const wrapped: any = function (
+    url: string | URL | Request,
+    options?: HttpRequestOptions,
+  ) {
+    const method = (options?.method ?? "GET").toUpperCase();
+    assertRequestActive(method, url);
+    return http(url, options);
+  };
+
+  for (const methodName of METHODS) {
+    wrapped[methodName] = (url: string | URL | Request, options?: HttpRequestOptions) => {
+      assertRequestActive(methodName.toUpperCase(), url);
+      return http[methodName](url, options);
+    };
+  }
+
+  wrapped.extend = (options: HttpRequestOptions): HttpClient =>
+    buildActivationAwareHttpClient(
+      pluginName,
+      activation,
+      http.extend(options),
+    );
+
+  return wrapped as HttpClient;
+}
+
 function buildLazyPluginDescriptors(
   // deno-lint-ignore no-explicit-any
-  plugins: Record<string, PluginFactory<any>>,
+  plugins: Record<string, PluginFactory<any> | PluginEntry<any>>,
 ): PropertyDescriptorMap {
   const descriptors: PropertyDescriptorMap = {};
 
-  for (const [name, factory] of Object.entries(plugins)) {
+  for (const [name, rawEntry] of Object.entries(plugins)) {
     if (RESERVED_KEYS.has(name)) {
       throw new Error(
         `Plugin name "${name}" conflicts with a reserved configure() field. ` +
           `Choose a different key (reserved: ${[...RESERVED_KEYS].join(", ")}).`,
       );
     }
+    const entry = normalizePluginEntry(rawEntry);
     const cache = new WeakMap<InternalRuntime, unknown>();
 
     descriptors[name] = {
       get() {
         const runtime = getRuntime();
+        const tagDecision = evaluateTagActivation(entry.activation, runtime);
+        if (!tagDecision.active) {
+          const testId = runtime.test?.id;
+          throw new Error(
+            `Plugin "${name}" is inactive${testId ? ` for test "${testId}"` : ""}: ${tagDecision.reason}.`,
+          );
+        }
+
         if (cache.has(runtime)) return cache.get(runtime);
 
         // Build the augmented runtime that plugins see
         const augmented: GlubeanRuntime = {
           vars: runtime.vars,
           secrets: runtime.secrets,
-          http: runtime.http,
+          http: buildActivationAwareHttpClient(
+            name,
+            entry.activation,
+            runtime.http,
+          ),
+          test: runtime.test,
           requireVar,
           requireSecret,
           resolveTemplate: (template: string) => resolveTemplate(template, runtime.vars, runtime.secrets),
         };
 
-        const instance = factory.create(augmented);
+        const instance = entry.factory.create(augmented);
         cache.set(runtime, instance);
         return instance;
       },
@@ -414,7 +601,10 @@ export function configure<
   V extends Record<string, string> = Record<string, string>,
   S extends Record<string, string> = Record<string, string>,
   // deno-lint-ignore no-explicit-any
-  P extends Record<string, PluginFactory<any>> = Record<string, never>,
+  P extends Record<string, PluginFactory<any> | PluginEntry<any>> = Record<
+    string,
+    never
+  >,
 >(
   options: ConfigureOptions & {
     vars?: { [K in keyof V]: string };

--- a/packages/sdk/configure.ts
+++ b/packages/sdk/configure.ts
@@ -467,7 +467,7 @@ function buildActivationAwareHttpClient(
     url: string | URL | Request,
     options?: HttpRequestOptions,
   ) {
-    const method = (options?.method ?? "GET").toUpperCase();
+    const method = (options?.method ?? (url instanceof Request ? url.method : "GET")).toUpperCase();
     assertRequestActive(method, url);
     return http(url, options);
   };

--- a/packages/sdk/configure_test.ts
+++ b/packages/sdk/configure_test.ts
@@ -15,12 +15,14 @@ function setRuntime(
   vars: Record<string, string> = {},
   secrets: Record<string, string> = {},
   http?: HttpClient,
+  test?: { id: string; tags: string[] },
 ) {
   // deno-lint-ignore no-explicit-any
   (globalThis as any).__glubeanRuntime = {
     vars,
     secrets,
     http: http ?? createMockHttp(),
+    test,
   };
   return () => {
     // deno-lint-ignore no-explicit-any
@@ -966,6 +968,108 @@ Deno.test("configure() without plugins - works as before", () => {
       vars: { baseUrl: "base_url" },
     });
     assertEquals(result.vars.baseUrl, "https://api.example.com");
+  } finally {
+    cleanup();
+  }
+});
+
+// =============================================================================
+// Plugin and HTTP activation
+// =============================================================================
+
+Deno.test("plugins - supports { factory, activation } entry wrapper", () => {
+  const cleanup = setRuntime({}, {}, undefined, { id: "t1", tags: [] });
+  try {
+    const result = configure({
+      plugins: {
+        wrapped: {
+          factory: definePlugin((_runtime) => ({ ok: true })),
+          activation: {
+            tags: { enable: ["smoke"] },
+          },
+        },
+      },
+    });
+
+    assertThrows(
+      () => result.wrapped.ok,
+      Error,
+      "activation.tags.enable",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("plugins - tags.enable activates plugin when tag matches", () => {
+  const cleanup = setRuntime({}, {}, undefined, { id: "t1", tags: ["smoke"] });
+  try {
+    const result = configure({
+      plugins: {
+        gated: {
+          factory: definePlugin((_runtime) => ({ ok: true })),
+          activation: { tags: { enable: ["smoke"] } },
+        },
+      },
+    });
+    assertEquals(result.gated.ok, true);
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("plugins - tags.disable takes precedence over tags.enable", () => {
+  const cleanup = setRuntime({}, {}, undefined, {
+    id: "t1",
+    tags: ["smoke", "no-auth"],
+  });
+  try {
+    const result = configure({
+      plugins: {
+        gated: {
+          factory: definePlugin((_runtime) => ({ ok: true })),
+          activation: {
+            tags: {
+              enable: ["smoke"],
+              disable: ["no-auth"],
+            },
+          },
+        },
+      },
+    });
+    assertThrows(
+      () => result.gated.ok,
+      Error,
+      "matches activation.tags.disable",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("plugins - requests.exclude blocks plugin runtime.http calls", () => {
+  const cleanup = setRuntime({}, {}, createMockHttp(), { id: "t1", tags: [] });
+  try {
+    const result = configure({
+      plugins: {
+        secureApi: {
+          factory: definePlugin((runtime) => ({
+            login: () => runtime.http.get("https://api.example.com/auth/login"),
+          })),
+          activation: {
+            requests: {
+              exclude: [{ method: "GET", path: "/auth/login" }],
+            },
+          },
+        },
+      },
+    });
+
+    assertThrows(
+      () => result.secureApi.login(),
+      Error,
+      "inactive for request GET https://api.example.com/auth/login",
+    );
   } finally {
     cleanup();
   }

--- a/packages/sdk/deno.json
+++ b/packages/sdk/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/sdk",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts",

--- a/packages/sdk/types.ts
+++ b/packages/sdk/types.ts
@@ -761,7 +761,7 @@ export interface ConfigureOptions {
    * ```
    */
   // deno-lint-ignore no-explicit-any
-  plugins?: Record<string, PluginFactory<any>>;
+  plugins?: Record<string, PluginFactory<any> | PluginEntry<any>>;
 }
 
 /**
@@ -915,6 +915,139 @@ export interface PluginFactory<T> {
 }
 
 /**
+ * Metadata about the currently running test.
+ *
+ * This is exposed to plugins so they can make deterministic activation decisions
+ * based on test identity and tags.
+ *
+ * @example
+ * ```ts
+ * definePlugin((runtime) => ({
+ *   currentTest: runtime.test?.id ?? "unknown",
+ *   tags: runtime.test?.tags ?? [],
+ * }));
+ * ```
+ */
+export interface GlubeanRuntimeTestMetadata {
+  /** Test ID currently being executed. */
+  id: string;
+  /** Normalized test tags (always an array). */
+  tags: string[];
+}
+
+/**
+ * Matcher for request-level plugin activation.
+ *
+ * A matcher can target:
+ * - HTTP method (`GET`, `POST`, ...)
+ * - request path (`/auth/login`)
+ * - full URL (`https://api.example.com/auth/login`)
+ *
+ * String values use prefix matching. Use `RegExp` for exact/pattern matches.
+ *
+ * @example Exclude common auth endpoints
+ * ```ts
+ * requests: {
+ *   exclude: [
+ *     { method: "POST", path: /^\/auth\/(login|signup|logout)$/ },
+ *   ],
+ * }
+ * ```
+ */
+export interface RequestMatcher {
+  /** HTTP method(s), case-insensitive. */
+  method?: string | string[];
+  /** Pathname matcher (e.g. `/auth/login`). */
+  path?: string | RegExp;
+  /** Full URL matcher. */
+  url?: string | RegExp;
+}
+
+/**
+ * Activation rules for SDK plugins.
+ *
+ * Defaults:
+ * - Missing activation config means "active"
+ * - `disable` rules take precedence over `enable`
+ * - `exclude` rules take precedence over `include`
+ *
+ * @example Enable plugin only for smoke tests
+ * ```ts
+ * activation: {
+ *   tags: { enable: ["smoke"] },
+ * }
+ * ```
+ *
+ * @example Enable globally, except login/logout
+ * ```ts
+ * activation: {
+ *   requests: {
+ *     exclude: [
+ *       { method: "POST", path: /^\/auth\/(login|logout)$/ },
+ *     ],
+ *   },
+ * }
+ * ```
+ */
+export interface PluginActivation {
+  /**
+   * Test-tag activation.
+   * - `enable`: active only when at least one tag matches
+   * - `disable`: force inactive when any tag matches
+   */
+  tags?: {
+    enable?: string[];
+    disable?: string[];
+  };
+  /**
+   * Request activation for plugin-owned HTTP traffic.
+   * - `include`: active only when request matches at least one rule
+   * - `exclude`: force inactive when request matches any rule
+   */
+  requests?: {
+    include?: RequestMatcher[];
+    exclude?: RequestMatcher[];
+  };
+}
+
+/**
+ * Plugin entry wrapper for `configure({ plugins })`.
+ *
+ * This preserves backward compatibility with the factory-only style while
+ * enabling per-plugin activation policies.
+ *
+ * @template T Plugin client type returned by `factory.create()`
+ *
+ * @example Existing style (still supported)
+ * ```ts
+ * plugins: {
+ *   gql: graphql({ endpoint: "GRAPHQL_URL" }),
+ * }
+ * ```
+ *
+ * @example New style with activation
+ * ```ts
+ * plugins: {
+ *   authClient: {
+ *     factory: authPlugin(),
+ *     activation: {
+ *       tags: { disable: ["public"] },
+ *       requests: {
+ *         exclude: [{ path: /^\/auth\/(login|signup|logout)$/ }],
+ *       },
+ *     },
+ *   },
+ * }
+ * ```
+ */
+export interface PluginEntry<T> {
+  /** The plugin factory (same object previously accepted directly). */
+  factory: PluginFactory<T>;
+  /** Optional activation policy for this plugin. */
+  activation?: PluginActivation;
+}
+
+/**
  * Runtime context available to plugin factories.
  * Exposes the same capabilities the harness provides to configure().
  *
@@ -939,6 +1072,8 @@ export interface GlubeanRuntime {
   secrets: Record<string, string>;
   /** Pre-configured HTTP client with auto-tracing */
   http: HttpClient;
+  /** Metadata of the currently executing test, if available. */
+  test?: GlubeanRuntimeTestMetadata;
   /** Require a var (throws if missing) */
   requireVar(key: string): string;
   /** Require a secret (throws if missing) */
@@ -952,7 +1087,9 @@ export interface GlubeanRuntime {
  * Used internally by `configure()` to infer the return type.
  */
 export type ResolvePlugins<P> = {
-  [K in keyof P]: P[K] extends PluginFactory<infer T> ? T : never;
+  [K in keyof P]: P[K] extends PluginFactory<infer T> ? T
+    : P[K] extends PluginEntry<infer T> ? T
+    : never;
 };
 
 /**

--- a/packages/worker/deno.json
+++ b/packages/worker/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/worker",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "exports": {
     ".": "./mod.ts",
     "./cli": "./cli.ts"

--- a/packages/worker/executor.ts
+++ b/packages/worker/executor.ts
@@ -639,6 +639,10 @@ export async function executeBundle(
             vars: context.vars ?? {},
             // Secrets are loaded locally, never from RuntimeContext
             secrets,
+            test: {
+              id: test.testId,
+              tags: test.tags,
+            },
             networkPolicy: toRunnerNetworkPolicy(config),
           };
           const result = await executor.execute(


### PR DESCRIPTION
Plugins now support optional activation policies controlled entirely by the caller — plugin authors remain unaware of activation logic.

- Tag-based activation: `tags.enable` / `tags.disable`
- Request-based activation: `requests.include` / `requests.exclude`
- New types: PluginActivation, PluginEntry, RequestMatcher, GlubeanRuntimeTestMetadata
- Runner/harness/worker pass test metadata (id, tags) to runtime
- Auth package unchanged (zero coupling with activation layer)