### PR TITLE
chore(scanner): retrigger JSR publish for 0.11.3

### DIFF
--- a/packages/scanner/deno.json
+++ b/packages/scanner/deno.json
@@ -6,7 +6,7 @@
     "./static": "./static.ts"
   },
   "license": "MIT",
-  "description": "Glubean Scanner - Static analysis for Glubean test files",
+  "description": "Static analysis for Glubean test files",
   "publish": {
     "exclude": [
       "*_test.ts",


### PR DESCRIPTION
Touches scanner/deno.json so the auto-publish workflow detects a change and publishes scanner 0.11.3.