### PR TITLE
chore(scanner): bump to 0.11.4 for JSR publish

### DIFF
--- a/packages/scanner/deno.json
+++ b/packages/scanner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/scanner",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "exports": {
     ".": "./mod.ts",
     "./static": "./static.ts"


### PR DESCRIPTION
0.11.3 publish failed due to test errors (fixed in #54). Bump to 0.11.4 to retrigger.