### PR TITLE
feat(sdk,runner,cli): Plugin Action Protocol

### DIFF
--- a/docs/proposals/mcp-testing-mvp.md
+++ b/docs/proposals/mcp-testing-mvp.md
@@ -1,0 +1,353 @@
+# Proposal: MCP Testing — Protocol & Agent Behavior
+
+**Status**: Discussion\
+**Date**: 2026-02-25\
+**Updated**: 2026-02-26
+
+## Problem
+
+MCP servers have **two correctness surfaces** that need automated regression coverage:
+
+### 1. Protocol correctness
+
+The server must respond correctly to MCP protocol operations (`initialize`, `tools/list`, `tools/call`, error handling).
+This is analogous to API contract testing — if `callTool("ping", {})` returns the wrong shape, nothing works.
+
+Glubean has its own MCP server (`@glubean/mcp`) and needs reliable regression tests beyond ad-hoc manual checks. Current
+tooling can run Glubean tests well, but MCP adds complexity: multiple transports, session lifecycle, and sandbox
+permissions.
+
+### 2. Tool routing correctness (AI behavior regression)
+
+An MCP server's tool descriptions and parameter schemas are effectively **prompts written for LLMs**. When an AI agent
+decides which tool to call for a given user request, it relies on these descriptions. This creates a fragile contract
+that breaks silently when:
+
+- **A new model is released** — GPT-5, Claude 4.5, or Gemini updates may interpret the same tool descriptions
+  differently, routing prompts to wrong tools or skipping tools entirely.
+- **Tool descriptions change** — Rewording a description (even synonyms) can shift model preferences.
+- **Tools are added or removed** — A new tool with overlapping description may "steal" calls from existing tools.
+- **Parameter schemas change** — Altered required fields may cause models to skip the tool or pass wrong arguments.
+- **Provider-side system prompt changes** — Even with no local changes, AI providers can update internal tool-calling
+  behavior.
+
+Today there is no automated way to detect these regressions. Teams discover them when users report "the AI stopped using
+my MCP tool" — after the damage is done.
+
+## Goal
+
+Ship MCP testing in Glubean across two layers:
+
+1. **Protocol layer**: Verify the MCP server works correctly at the protocol level (Phase 1)
+2. **Agent behavior layer**: Verify that AI models route prompts to the correct tools (Phase 2)
+
+Both layers should be:
+
+- Useful for Glubean's own MCP package immediately
+- Reusable by anyone testing their own MCP servers
+- Safe for cloud execution defaults
+- Compatible with the existing SDK plugin architecture
+
+## Non-Goals
+
+1. Full MCP conformance-suite parity
+2. Visual protocol timeline UI
+3. Auto-generation of tests from server schemas
+4. Replacing model evaluation benchmarks (we test tool routing, not general model quality)
+
+---
+
+## Phase 1: Protocol Testing (MVP)
+
+### Product Decision
+
+MVP supports **remote MCP over HTTP/Streamable HTTP only** (server is started by user or CI service).
+
+`stdio` transport is deferred to Phase 3 because it requires `--allow-run` and process lifecycle management.
+
+### Why This Slice
+
+1. Avoids immediate `--allow-run` dependency
+2. Fits current cloud-safe defaults better
+3. Covers the most CI-friendly setup (service already running)
+4. Lets us validate demand before building heavy transport/runtime machinery
+
+### API Shape
+
+Use SDK plugin architecture (`configure({ plugins })`) with a new plugin package: `@glubean/mcp-test`.
+
+```ts
+import { configure, test } from "@glubean/sdk";
+import { mcp } from "@glubean/mcp-test";
+
+const { mcpClient } = configure({
+  plugins: {
+    mcpClient: mcp({
+      transport: "http",
+      baseUrl: "{{MCP_BASE_URL}}",
+      timeoutMs: 10_000,
+    }),
+  },
+});
+
+export const listTools = test("mcp-list-tools", async (ctx) => {
+  const tools = await mcpClient.listTools();
+  ctx.expect(tools.length).toBeGreaterThan(0).orFail("Server should expose at least one tool");
+});
+
+export const callPing = test("mcp-call-ping", async (ctx) => {
+  const result = await mcpClient.callTool("ping", { message: "hello" });
+  ctx.expect(result.isError).toBe(false);
+});
+```
+
+### Capability Set
+
+1. `initialize` handshake (automatically on first call)
+2. `listTools()`
+3. `callTool(name, args)`
+4. Structured protocol error surface (invalid response, timeout, tool-not-found)
+5. Optional request/response tracing as Glubean test events
+
+### Execution and Permissions
+
+**Self-hosted / Local:** HTTP MCP testing works with existing network permission controls (`allowNet`).
+
+**Cloud worker:** Keep default sandbox posture strict:
+
+1. No subprocess spawning requirement
+2. No extra permissions beyond network policy already required for outbound calls
+3. Continue redaction and network guardrails unchanged
+
+### Internal Design
+
+1. Add new package `packages/mcp-test` (plugin only, no runner changes)
+2. Build a small typed MCP client wrapper inside the package
+3. Map MCP failures to Glubean assertion-friendly error objects/messages
+4. Reuse existing SDK plugin lazy initialization pattern
+5. Unit tests for client behavior + integration test against `packages/mcp` test server fixture
+
+### Test Plan
+
+1. `listTools` succeeds and returns at least one tool
+2. `callTool` success path
+3. `callTool` unknown tool returns deterministic error shape
+4. Request timeout surfaces clear diagnostic
+5. Server-side protocol error is captured with enough context for AI-assisted fixing
+
+### Release Plan
+
+1. Ship as experimental package (`@glubean/mcp-test`)
+2. Add a short guide in `docs/guides/mcp.md` with one end-to-end example
+3. Use it internally to test `@glubean/mcp` in CI before wider promotion
+
+### Success Criteria (4-6 weeks)
+
+1. Glubean MCP regressions are caught by automated tests before release
+2. At least one external user project adopts the plugin for MCP regression testing
+3. No cloud security relaxation required for MVP rollout
+
+---
+
+## Phase 2: Agent Tool Routing Regression
+
+### Problem Statement
+
+Protocol tests verify "the tool works when called." But who verifies "the AI will call the right tool"?
+
+MCP tool descriptions are prompts. When a model is upgraded, tool descriptions change, or new tools are added, AI
+routing behavior can silently drift. This is the **MCP equivalent of prompt regression** — and it is the #1 concern for
+MCP server maintainers shipping to production.
+
+### Core Testing Model
+
+Given a list of prompts, verify each one triggers the expected set of tool calls:
+
+```
+Prompt → LLM + MCP Tools → [tool_call_1, tool_call_2, ...] → Assert tool names ⊇ expected set
+```
+
+The key insight: **assert on what the AI does (which tools it calls), not what it says (text output).** Tool routing is
+far more deterministic than text generation — the same prompt with reasonable tool descriptions will consistently
+trigger the same tools across runs, even if the final text response varies.
+
+### API Shape
+
+Separate plugin package (working name: `@glubean/mcp-agent-test`) that composes with `@glubean/mcp-test` and any AI SDK.
+The reference implementation uses Vercel AI SDK (`ai`), but the plugin interface should be provider-agnostic.
+
+```ts
+import { configure, test } from "@glubean/sdk";
+import { mcpAgent } from "@glubean/mcp-agent-test";
+
+const { agent } = configure({
+  vars: { mcpUrl: "MCP_SERVER_URL" },
+  secrets: { apiKey: "OPENAI_API_KEY" },
+  plugins: {
+    agent: mcpAgent({
+      transport: "http",
+      baseUrl: "MCP_SERVER_URL",
+      model: "openai:gpt-4o-mini",
+    }),
+  },
+});
+
+export const toolRouting = test.each([
+  {
+    prompt: "List all test files in the project",
+    expectedTools: ["glubean_list_test_files"],
+  },
+  {
+    prompt: "Run the health check test and show results",
+    expectedTools: ["glubean_list_test_files", "glubean_run_local_file"],
+  },
+  {
+    prompt: "What's wrong with my project setup?",
+    expectedTools: ["glubean_diagnose_config"],
+  },
+])("tool-routing-$prompt", async (ctx, { prompt, expectedTools }) => {
+  const result = await agent.run(prompt);
+  const calledTools = result.toolCalls.map((tc) => tc.toolName);
+
+  for (const tool of expectedTools) {
+    ctx.expect(calledTools).toContain(tool)
+      .orFail(`Prompt "${prompt}" should trigger ${tool}`);
+  }
+
+  ctx.log(`Expected: [${expectedTools.join(", ")}]`);
+  ctx.log(`Actual:   [${calledTools.join(", ")}]`);
+});
+```
+
+### Data-Driven Test Matrix (YAML)
+
+Prompt-to-tool mappings should be maintainable by non-engineers (product, QA):
+
+```yaml
+# data/mcp-routing.yaml
+- prompt: "List all test files"
+  tools: ["glubean_list_test_files"]
+- prompt: "Run health check and show results"
+  tools: ["glubean_list_test_files", "glubean_run_local_file"]
+- prompt: "Diagnose my project"
+  tools: ["glubean_diagnose_config"]
+```
+
+```ts
+import { fromYaml, test } from "@glubean/sdk";
+
+interface RoutingCase {
+  prompt: string;
+  tools: string[];
+}
+
+export const toolRouting = test.each(
+  fromYaml<RoutingCase>("./data/mcp-routing.yaml"),
+)("mcp-routing-$prompt", async (ctx, { prompt, tools }) => {
+  const result = await agent.run(prompt);
+  const called = result.toolCalls.map((tc) => tc.toolName);
+  for (const t of tools) {
+    ctx.expect(called).toContain(t);
+  }
+});
+```
+
+### Assertion Strategies
+
+Tests should support both strict and loose matching:
+
+```ts
+// Superset (loose): these tools must be called, extra calls allowed
+for (const tool of expectedTools) {
+  ctx.expect(calledTools).toContain(tool);
+}
+
+// Exact (strict): must call exactly these tools, no more
+ctx.expect(new Set(calledTools)).toEqual(new Set(expectedTools));
+
+// Exclusion: must NOT call certain tools
+ctx.expect(calledTools).not.toContain("glubean_run_local_file");
+```
+
+### Multi-Model Matrix
+
+The same routing cases can be run across models to detect model-specific regressions:
+
+```ts
+const models = ["openai:gpt-4o-mini", "openai:gpt-4o", "anthropic:claude-sonnet"];
+
+for (const model of models) {
+  export const routing = test.each(cases)(
+    `routing-${model}-$prompt`,
+    async (ctx, { prompt, expectedTools }) => {
+      const result = await agent.run(prompt, { model });
+      // ...assertions...
+    },
+  );
+}
+```
+
+This produces a prompt × model regression matrix, catching cases where a model upgrade breaks routing for specific
+prompts.
+
+### Execution Considerations
+
+| Dimension       | Guidance                                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------------- |
+| **Cost**        | Use smallest viable model (`gpt-4o-mini`); routing decisions rarely need frontier models          |
+| **Timeout**     | Set `meta({ timeout: 60_000 })` — multi-step LLM calls are slower than direct HTTP                |
+| **CI strategy** | Tag with `["mcp-agent"]`; run only when MCP server or tool descriptions change, not every commit  |
+| **Flakiness**   | If a prompt intermittently routes incorrectly, tighten the prompt wording before adding retries   |
+| **Tracing**     | Record each tool call as a Glubean event; on failure, the trace shows the full AI reasoning chain |
+
+### Permissions
+
+Same as Phase 1 — outbound HTTP only. The plugin calls the LLM API (e.g., OpenAI) and the MCP server, both over HTTP. No
+additional sandbox permissions required.
+
+### Internal Design
+
+1. Add `packages/mcp-agent-test` as a separate plugin package
+2. Depend on `@glubean/mcp-test` for MCP client functionality
+3. Reference implementation wraps Vercel AI SDK (`ai` + `@ai-sdk/openai`)
+4. Plugin interface is provider-agnostic: accept any `generateText`-compatible function
+5. Return structured result: `{ text, toolCalls, toolResults, steps }`
+
+### Success Criteria (4-6 weeks after Phase 1)
+
+1. Glubean MCP tool routing is regression-tested across at least 2 models
+2. Routing test matrix catches at least one real regression (tool description or model change)
+3. At least one external MCP server project adopts the tool routing test pattern
+4. Non-engineer team members can add routing cases via YAML without code changes
+
+---
+
+## Phase 3: stdio Transport & Transport Matrix
+
+Add `stdio` transport support with explicit permission model:
+
+1. Local/self-hosted: opt-in `--allow-run`
+2. Cloud: default disabled unless dedicated isolated worker profile is introduced
+3. Transport matrix mode: run the same protocol test cases across `http` and `stdio`
+4. Agent routing tests should also support stdio-backed MCP servers transparently
+
+---
+
+## Package Structure
+
+| Package                   | Layer                   | Dependencies                              | Phase |
+| ------------------------- | ----------------------- | ----------------------------------------- | ----- |
+| `@glubean/mcp-test`       | Protocol testing        | `@modelcontextprotocol/sdk`               | 1     |
+| `@glubean/mcp-agent-test` | Tool routing regression | `@glubean/mcp-test`, `ai` (Vercel AI SDK) | 2     |
+
+Both are SDK plugins (`definePlugin()`). No runner changes required in any phase.
+
+## Open Questions
+
+1. Should Phase 1 target Streamable HTTP only, or include SSE from day one?
+2. Do we want built-in assertion helpers (`toHaveTool`, `toReturnText`) in Phase 1 or leave assertions generic?
+3. Should we store protocol transcripts as artifacts in `.glubean/` for diff-based regression?
+4. Should `@glubean/mcp-agent-test` be an official package or start as a cookbook recipe to validate demand first?
+5. For multi-model matrix testing, should we provide a built-in model rotation helper or let users compose with
+   `test.each()` manually?
+6. How do we handle cost attribution for LLM-based routing tests in the cloud runner billing model?

--- a/packages/cli/commands/run.ts
+++ b/packages/cli/commands/run.ts
@@ -110,7 +110,7 @@ interface LogEntry {
   timestamp: string;
   testId: string;
   testName: string;
-  type: "log" | "trace" | "assertion" | "metric" | "error" | "result";
+  type: "log" | "trace" | "assertion" | "metric" | "error" | "result" | "action" | "event";
   message: string;
   data?: unknown;
 }
@@ -777,6 +777,31 @@ export async function runCommand(
             const body = JSON.stringify(event.data.responseBody);
             console.log(
               `        ${colors.dim}res: ${body.slice(0, 120)}${body.length > 120 ? "…" : ""}${colors.reset}`,
+            );
+          }
+          break;
+        }
+
+        case "action": {
+          const a = event.data;
+          // Skip http:request actions — already displayed by the trace handler
+          if (a.category === "http:request") break;
+          const statusColor = a.status === "ok" ? colors.green : a.status === "error" ? colors.red : colors.yellow;
+          const statusIcon = a.status === "ok" ? "✓" : a.status === "error" ? "✗" : "⏱";
+          addLogEntry("action", `[${a.category}] ${a.target} ${a.duration}ms ${a.status}`, a);
+          console.log(
+            `      ${colors.dim}↳${colors.reset} ${colors.cyan}${a.category}${colors.reset} ${a.target} ${colors.dim}${a.duration}ms${colors.reset} ${statusColor}${statusIcon}${colors.reset}`,
+          );
+          break;
+        }
+
+        case "event": {
+          const ev = event.data;
+          addLogEntry("event", `[${ev.type}]`, ev);
+          if (effectiveRun.verbose) {
+            const summary = JSON.stringify(ev.data).slice(0, 80);
+            console.log(
+              `      ${colors.dim}[${ev.type}] ${summary}${colors.reset}`,
             );
           }
           break;

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.11.19",
+  "version": "0.12.0",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",
@@ -8,8 +8,8 @@
     "exclude": ["*_test.ts", ".glubean/"]
   },
   "imports": {
-    "@glubean/sdk": "jsr:@glubean/sdk@^0.11.0",
-    "@glubean/runner": "jsr:@glubean/runner@^0.11.0",
+    "@glubean/sdk": "jsr:@glubean/sdk@^0.12.0",
+    "@glubean/runner": "jsr:@glubean/runner@^0.12.0",
     "@glubean/scanner": "jsr:@glubean/scanner@^0.11.0",
     "@glubean/redaction": "jsr:@glubean/redaction@^0.11.0",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.8",

--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/runner",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Runner - Test executor with sandboxed Deno subprocess",
@@ -12,7 +12,7 @@
     ]
   },
   "imports": {
-    "@glubean/sdk": "jsr:@glubean/sdk@^0.11.0",
+    "@glubean/sdk": "jsr:@glubean/sdk@^0.12.0",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "@std/assert": "jsr:@std/assert@^1.0.0",
     "ky": "npm:ky@^1.14.0"

--- a/packages/runner/executor.ts
+++ b/packages/runner/executor.ts
@@ -1,4 +1,4 @@
-import type { ApiTrace } from "@glubean/sdk";
+import type { ApiTrace, GlubeanAction, GlubeanEvent } from "@glubean/sdk";
 import { resolveAllowNetFlag } from "./config.ts";
 import type { SharedRunConfig } from "./config.ts";
 
@@ -32,6 +32,8 @@ export type ExecutionEvent =
     stepIndex?: number;
   }
   | { type: "trace"; data: ApiTrace; stepIndex?: number }
+  | { type: "action"; data: GlubeanAction; stepIndex?: number }
+  | { type: "event"; data: GlubeanEvent; stepIndex?: number }
   | {
     type: "warning";
     condition: boolean;
@@ -190,6 +192,20 @@ export type TimelineEvent =
     testId?: string;
     stepIndex?: number;
     data: ApiTrace;
+  }
+  | {
+    type: "action";
+    ts: number;
+    testId?: string;
+    stepIndex?: number;
+    data: GlubeanAction;
+  }
+  | {
+    type: "event";
+    ts: number;
+    testId?: string;
+    stepIndex?: number;
+    data: GlubeanEvent;
   }
   | {
     type: "metric";
@@ -921,6 +937,28 @@ export class TestExecutor {
         case "trace":
           timelineEvent = {
             type: "trace",
+            ts,
+            ...(includeTestId && { testId }),
+            ...(event.stepIndex !== undefined && {
+              stepIndex: event.stepIndex,
+            }),
+            data: event.data,
+          };
+          break;
+        case "action":
+          timelineEvent = {
+            type: "action",
+            ts,
+            ...(includeTestId && { testId }),
+            ...(event.stepIndex !== undefined && {
+              stepIndex: event.stepIndex,
+            }),
+            data: event.data,
+          };
+          break;
+        case "event":
+          timelineEvent = {
+            type: "event",
             ts,
             ...(includeTestId && { testId }),
             ...(event.stepIndex !== undefined && {

--- a/packages/runner/harness.ts
+++ b/packages/runner/harness.ts
@@ -21,6 +21,8 @@ import type {
   ApiTrace,
   AssertionDetails,
   AssertionResultInput,
+  GlubeanAction,
+  GlubeanEvent,
   HttpClient as _HttpClient,
   HttpSchemaOptions,
   MetricOptions,
@@ -594,6 +596,42 @@ const ctx = {
       JSON.stringify({
         type: "trace",
         data: request,
+        ...(currentStepIndex !== null && { stepIndex: currentStepIndex }),
+      }),
+    );
+    // Backward compat: also emit as a typed action for timeline/filtering
+    let pathname: string;
+    try {
+      pathname = new URL(request.url).pathname;
+    } catch {
+      pathname = request.url;
+    }
+    ctx.action({
+      category: "http:request",
+      target: `${request.method} ${pathname}`,
+      duration: request.duration,
+      status: request.status >= 400 ? "error" : "ok",
+      detail: { method: request.method, url: request.url, httpStatus: request.status },
+    });
+  },
+
+  // Action recording function
+  action: (a: GlubeanAction) => {
+    console.log(
+      JSON.stringify({
+        type: "action",
+        data: a,
+        ...(currentStepIndex !== null && { stepIndex: currentStepIndex }),
+      }),
+    );
+  },
+
+  // Structured event emission
+  event: (ev: GlubeanEvent) => {
+    console.log(
+      JSON.stringify({
+        type: "event",
+        data: ev,
         ...(currentStepIndex !== null && { stepIndex: currentStepIndex }),
       }),
     );
@@ -1281,6 +1319,9 @@ function withEnvFallback(
   // deno-lint-ignore no-explicit-any
   http: (ctx as any).http,
   test: runtimeTest,
+  action: ctx.action,
+  event: ctx.event,
+  log: ctx.log,
 };
 
 try {

--- a/packages/sdk/configure.ts
+++ b/packages/sdk/configure.ts
@@ -55,6 +55,8 @@ import type {
   ConfigureHttpOptions,
   ConfigureOptions,
   ConfigureResult,
+  GlubeanAction,
+  GlubeanEvent,
   GlubeanRuntime,
   HttpClient,
   HttpRequestOptions,
@@ -82,6 +84,9 @@ export interface InternalRuntime {
   secrets: Record<string, string>;
   http: HttpClient;
   test?: GlubeanRuntime["test"];
+  action?(a: GlubeanAction): void;
+  event?(ev: GlubeanEvent): void;
+  log?(message: string, data?: unknown): void;
 }
 
 /**
@@ -519,6 +524,7 @@ function buildLazyPluginDescriptors(
         if (cache.has(runtime)) return cache.get(runtime);
 
         // Build the augmented runtime that plugins see
+        const noop = () => {};
         const augmented: GlubeanRuntime = {
           vars: runtime.vars,
           secrets: runtime.secrets,
@@ -531,6 +537,9 @@ function buildLazyPluginDescriptors(
           requireVar,
           requireSecret,
           resolveTemplate: (template: string) => resolveTemplate(template, runtime.vars, runtime.secrets),
+          action: runtime.action?.bind(runtime) ?? noop,
+          event: runtime.event?.bind(runtime) ?? noop,
+          log: runtime.log?.bind(runtime) ?? noop,
         };
 
         const instance = entry.factory.create(augmented);

--- a/packages/sdk/deno.json
+++ b/packages/sdk/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/sdk",
-  "version": "0.11.8",
+  "version": "0.12.0",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts",

--- a/packages/sdk/mod_test.ts
+++ b/packages/sdk/mod_test.ts
@@ -82,6 +82,8 @@ function createMockContext(
     log: () => {},
     assert: () => {},
     trace: () => {},
+    action: () => {},
+    event: () => {},
     metric: () => {},
     http: mockHttp as unknown as import("./types.ts").HttpClient,
     expect: <V>(actual: V) => new Expectation(actual, () => {}),

--- a/packages/sdk/types.ts
+++ b/packages/sdk/types.ts
@@ -424,6 +424,69 @@ export interface TestContext {
   trace(request: ApiTrace): void;
 
   /**
+   * Record a structured action to the test timeline.
+   *
+   * Actions are the primary unit of test observability. Every plugin interaction
+   * — browser click, API call, MCP tool invocation, DB query — should be
+   * recorded as an action.
+   *
+   * Actions appear in the Glubean dashboard timeline, are filterable by category,
+   * searchable by target, and aggregatable for trend analysis.
+   *
+   * @example Browser click
+   * ```ts
+   * ctx.action({
+   *   category: "browser:click",
+   *   target: "#submit-btn",
+   *   duration: 50,
+   *   status: "ok",
+   * });
+   * ```
+   *
+   * @example MCP tool call
+   * ```ts
+   * ctx.action({
+   *   category: "mcp:tool-call",
+   *   target: "get_weather",
+   *   duration: 300,
+   *   status: "ok",
+   *   detail: { args: { location: "Tokyo" } },
+   * });
+   * ```
+   */
+  action(a: GlubeanAction): void;
+
+  /**
+   * Emit a structured event with arbitrary payload.
+   *
+   * Use `ctx.event()` for structured data that doesn't fit the action model
+   * (no target/duration/status) but is more than a log message. Events are
+   * renderable by plugin-provided custom renderers in the dashboard.
+   *
+   * The distinction:
+   * - `ctx.log()` — text for humans reading logs
+   * - `ctx.event()` — structured data for machines/dashboard renderers
+   * - `ctx.action()` — typed interaction record for timeline/waterfall/filter
+   *
+   * @example Screenshot captured
+   * ```ts
+   * ctx.event({
+   *   type: "browser:screenshot",
+   *   data: { path: "/screenshots/after-login.png", fullPage: true, sizeKb: 142 },
+   * });
+   * ```
+   *
+   * @example MCP server connected
+   * ```ts
+   * ctx.event({
+   *   type: "mcp:connected",
+   *   data: { server: "weather-api", transport: "stdio", tools: ["get_weather"] },
+   * });
+   * ```
+   */
+  event(ev: GlubeanEvent): void;
+
+  /**
    * Report a numeric metric for performance tracking and trending.
    *
    * Metrics are stored separately from logs/traces with longer retention (90 days)
@@ -1080,6 +1143,24 @@ export interface GlubeanRuntime {
   requireSecret(key: string): string;
   /** Resolve {{key}} template placeholders from vars and secrets */
   resolveTemplate(template: string): string;
+
+  /**
+   * Record a typed interaction to the test timeline.
+   * Available to plugins during initialization and test execution.
+   */
+  action(a: GlubeanAction): void;
+
+  /**
+   * Emit a structured event. For data that doesn't fit the action model
+   * but needs to be surfaced in the dashboard with a custom renderer.
+   */
+  event(ev: GlubeanEvent): void;
+
+  /**
+   * Emit a log message. Convenience alias available to plugins
+   * without requiring the full TestContext.
+   */
+  log(message: string, data?: unknown): void;
 }
 
 /**
@@ -1582,6 +1663,108 @@ export interface ApiTrace {
   responseHeaders?: Record<string, string>;
   /** Optional response body */
   responseBody?: unknown;
+}
+
+/**
+ * A typed interaction record emitted by plugins.
+ *
+ * All fields except `detail` are required, ensuring consistent timeline
+ * rendering, filtering, and analytics across all plugin domains.
+ *
+ * @example Browser interaction
+ * ```ts
+ * ctx.action({
+ *   category: "browser:click",
+ *   target: "#submit-btn",
+ *   duration: 620,
+ *   status: "ok",
+ *   detail: { autoWaitMs: 580 },
+ * });
+ * ```
+ *
+ * @example HTTP request (auto-emitted by ctx.trace())
+ * ```ts
+ * ctx.action({
+ *   category: "http:request",
+ *   target: "POST /api/auth/login",
+ *   duration: 350,
+ *   status: "ok",
+ *   detail: { method: "POST", url: "/api/auth/login", httpStatus: 200 },
+ * });
+ * ```
+ */
+export interface GlubeanAction {
+  /**
+   * Namespaced action category for routing, filtering, and rendering.
+   *
+   * Convention: `"domain:verb"` where `domain` identifies the plugin
+   * (`http`, `browser`, `mcp`, `db`) and `verb` identifies the operation
+   * (`request`, `click`, `assert`, `query`).
+   */
+  category: string;
+
+  /**
+   * The target of the action — what was acted upon.
+   * Must be machine-readable for aggregation and search.
+   *
+   * Examples: `"#submit-btn"`, `"POST /api/users"`, `"get_weather"`.
+   */
+  target: string;
+
+  /** How long the action took, in milliseconds. */
+  duration: number;
+
+  /**
+   * Outcome of the action.
+   * - `"ok"` — completed successfully
+   * - `"error"` — failed (e.g., element not found, assertion mismatch)
+   * - `"timeout"` — timed out (e.g., actionability check exceeded limit)
+   */
+  status: "ok" | "error" | "timeout";
+
+  /**
+   * Domain-specific payload. Optional.
+   * Values must be JSON-serializable.
+   */
+  detail?: Record<string, unknown>;
+}
+
+/**
+ * A generic structured event emitted by plugins.
+ *
+ * Unlike `GlubeanAction` (which has required fields for timeline rendering),
+ * `GlubeanEvent` is a loosely-typed container for any structured data that
+ * plugins want to surface in the dashboard.
+ *
+ * Dashboard plugins can register custom renderers keyed on `type` to
+ * control how events are displayed. Without a custom renderer, events appear
+ * as collapsible JSON in the detail panel.
+ *
+ * @example Screenshot captured
+ * ```ts
+ * ctx.event({
+ *   type: "browser:screenshot",
+ *   data: { path: "/screenshots/login.png", fullPage: true, sizeKb: 142 },
+ * });
+ * ```
+ *
+ * @example MCP server connected
+ * ```ts
+ * ctx.event({
+ *   type: "mcp:connected",
+ *   data: { server: "weather-api", transport: "stdio", tools: ["get_weather"] },
+ * });
+ * ```
+ */
+export interface GlubeanEvent {
+  /**
+   * Namespaced event type. Convention: `"domain:noun"` or `"domain:description"`.
+   * Examples: `"browser:screenshot"`, `"mcp:connected"`, `"db:slow-query-warning"`.
+   */
+  type: string;
+
+  /** Structured payload. Must be JSON-serializable. */
+  data: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `ctx.action()` and `ctx.event()` APIs to the test harness context
- Enables plugins (e.g. `@glubean/browser`) to emit structured actions and events into the test trace timeline
- Required by `@glubean/browser@0.3.0` for browser action tracing and screenshot events

## Test plan
- [x] Existing tests pass after rebase
- [ ] Verify `@glubean/browser` tests work with the new SDK version
- [ ] Confirm JSR publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)