### PR TITLE
feat(cli): print screenshot paths in test output

### DIFF
--- a/packages/cli/commands/run.ts
+++ b/packages/cli/commands/run.ts
@@ -1297,6 +1297,26 @@ export async function runCommand(
     }
   }
 
+  // ── Screenshot paths ──────────────────────────────────────────────────
+  {
+    const screenshotPaths: string[] = [];
+    for (const run of collectedRuns) {
+      for (const event of run.events) {
+        if (event.type !== "event") continue;
+        const ev = event.data as { type?: string; data?: Record<string, unknown> };
+        if (ev.type === "browser:screenshot" && typeof ev.data?.path === "string") {
+          screenshotPaths.push(resolve(rootDir, ev.data.path));
+        }
+      }
+    }
+    if (screenshotPaths.length > 0) {
+      for (const p of screenshotPaths) {
+        console.log(`${colors.dim}Screenshot: ${colors.reset}${p}`);
+      }
+      console.log();
+    }
+  }
+
   // ── Cloud upload ────────────────────────────────────────────────────────
   if (options.upload) {
     const { resolveToken, resolveProjectId, resolveApiUrl } = await import(

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",


### PR DESCRIPTION
## Summary
- Print `Screenshot: /path/to/file.png` lines at the end of test output
- Extracts paths from `browser:screenshot` events emitted by `@glubean/browser`
- Shown alongside existing Trace and Result JSON paths

## Test plan
- [ ] Run browser test with intentional failure, verify screenshot paths printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)