### PR TITLE
chore: bump all packages to 0.12.2

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -33,7 +33,8 @@
     "@std/dotenv": "jsr:@std/dotenv@^0.225.0"
   },
   "fmt": {
-    "lineWidth": 120
+    "lineWidth": 120,
+    "exclude": ["CLAUDE.md"]
   },
   "tasks": {
     "setup": "git config core.hooksPath .githooks",

--- a/packages/auth/deno.json
+++ b/packages/auth/deno.json
@@ -1,13 +1,13 @@
 {
   "name": "@glubean/auth",
-  "version": "0.11.1",
+  "version": "0.12.2",
   "exports": {
     ".": "./mod.ts"
   },
   "license": "MIT",
   "description": "Auth helpers for Glubean — bearer, basic, apiKey, OAuth 2.0, and dynamic login",
   "imports": {
-    "@glubean/sdk": "jsr:@glubean/sdk@^0.11.0",
+    "@glubean/sdk": "jsr:@glubean/sdk@^0.12.0",
     "@std/encoding": "jsr:@std/encoding@^1.0.0"
   },
   "publish": {

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",
@@ -10,8 +10,8 @@
   "imports": {
     "@glubean/sdk": "jsr:@glubean/sdk@^0.12.0",
     "@glubean/runner": "jsr:@glubean/runner@^0.12.0",
-    "@glubean/scanner": "jsr:@glubean/scanner@^0.11.0",
-    "@glubean/redaction": "jsr:@glubean/redaction@^0.11.0",
+    "@glubean/scanner": "jsr:@glubean/scanner@^0.12.0",
+    "@glubean/redaction": "jsr:@glubean/redaction@^0.12.0",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.8",
     "@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.8",
     "@std/cli": "jsr:@std/cli@^1.0.0",

--- a/packages/graphql/deno.json
+++ b/packages/graphql/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/graphql",
-  "version": "0.11.1",
+  "version": "0.12.2",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts"
@@ -8,7 +8,7 @@
   "license": "MIT",
   "description": "GraphQL plugin for Glubean — wraps ctx.http with query/mutation helpers and auto-tracing",
   "imports": {
-    "@glubean/sdk": "jsr:@glubean/sdk@^0.11.0"
+    "@glubean/sdk": "jsr:@glubean/sdk@^0.12.0"
   },
   "publish": {
     "exclude": [

--- a/packages/graphql/mod_test.ts
+++ b/packages/graphql/mod_test.ts
@@ -99,6 +99,9 @@ function createMockRuntime(
         return val;
       });
     },
+    action() {},
+    event() {},
+    log() {},
   };
 }
 

--- a/packages/mcp/deno.json
+++ b/packages/mcp/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/mcp",
-  "version": "0.11.3",
+  "version": "0.12.2",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean MCP server - run checks and fetch facts for AI agents",
@@ -11,6 +11,6 @@
     ]
   },
   "imports": {
-    "@glubean/runner": "jsr:@glubean/runner@^0.11.0"
+    "@glubean/runner": "jsr:@glubean/runner@^0.12.0"
   }
 }

--- a/packages/redaction/deno.json
+++ b/packages/redaction/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/redaction",
-  "version": "0.11.1",
+  "version": "0.12.2",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Redaction Engine - Plugin-based secrets/PII detection and masking",

--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/runner",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Runner - Test executor with sandboxed Deno subprocess",

--- a/packages/scanner/deno.json
+++ b/packages/scanner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/scanner",
-  "version": "0.11.4",
+  "version": "0.12.2",
   "exports": {
     ".": "./mod.ts",
     "./static": "./static.ts"

--- a/packages/scanner/testdata/sample-project/api.test.ts
+++ b/packages/scanner/testdata/sample-project/api.test.ts
@@ -7,7 +7,7 @@
  * API Reference: @openapi.json
  */
 // deno-lint-ignore no-import-prefix
-import { test } from "jsr:@glubean/sdk@^0.11.0";
+import { test } from "jsr:@glubean/sdk@^0.12.0";
 
 // ============================================================================
 // Posts API Tests

--- a/packages/sdk/deno.json
+++ b/packages/sdk/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/sdk",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts",

--- a/packages/worker/deno.json
+++ b/packages/worker/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/worker",
-  "version": "0.11.2",
+  "version": "0.12.2",
   "exports": {
     ".": "./mod.ts",
     "./cli": "./cli.ts"
@@ -21,9 +21,9 @@
     "dev": "deno run --watch -A cli.ts"
   },
   "imports": {
-    "@glubean/runner": "jsr:@glubean/runner@^0.11.0",
-    "@glubean/redaction": "jsr:@glubean/redaction@^0.11.0",
-    "@glubean/sdk": "jsr:@glubean/sdk@^0.11.0",
+    "@glubean/runner": "jsr:@glubean/runner@^0.12.0",
+    "@glubean/redaction": "jsr:@glubean/redaction@^0.12.0",
+    "@glubean/sdk": "jsr:@glubean/sdk@^0.12.0",
     "@std/tar": "jsr:@std/tar@^0.1",
     "@std/tar/untar-stream": "jsr:@std/tar@^0.1/untar-stream",
     "@std/path": "jsr:@std/path@^1",


### PR DESCRIPTION
## Summary
- Unify all 9 workspace packages to 0.12.2 (patch bump for pre-launch)
- Fix GlubeanRuntime mock in graphql tests — add missing action/event/log stubs
- Exclude CLAUDE.md from deno fmt

## After merge
- Tag `v0.12.2` on main to trigger JSR publish
- Delete stale branches: fix/screenshot-output, fix/plugin-destructure, feat/action-protocol, fix/scanner-publish-v2, fix/scanner-publish, fix/trigger-publish, feat/cli-cloud-upload, fix/scanner-validate-tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)