### PR TITLE
fix(mcp): use static analysis for test discovery

### DIFF
--- a/packages/mcp/integration_test.ts
+++ b/packages/mcp/integration_test.ts
@@ -15,6 +15,15 @@ const FIXTURE_DIR = resolve(
   "simple-project",
 );
 
+// When running in the oss workspace, the harness subprocess needs the
+// workspace's deno.json to resolve local @glubean/* packages.
+// GLUBEAN_DEV_CONFIG tells the executor to use this config instead of
+// the test project's deno.json for harness import resolution.
+if (!Deno.env.get("GLUBEAN_DEV_CONFIG")) {
+  const workspaceRoot = resolve(new URL(".", import.meta.url).pathname, "..", "..");
+  Deno.env.set("GLUBEAN_DEV_CONFIG", resolve(workspaceRoot, "deno.json"));
+}
+
 // ---------------------------------------------------------------------------
 // Layer 1a: Pure helper unit tests
 // ---------------------------------------------------------------------------
@@ -70,7 +79,7 @@ Deno.test("loadEnvFile parses secrets file", async () => {
 });
 
 // ---------------------------------------------------------------------------
-// Layer 1b: discoverTestsFromFile (dynamic import, no subprocess)
+// Layer 1b: discoverTestsFromFile (static analysis, no import needed)
 // ---------------------------------------------------------------------------
 
 Deno.test("discoverTestsFromFile finds exported tests", async () => {

--- a/packages/mcp/mod.ts
+++ b/packages/mcp/mod.ts
@@ -17,10 +17,10 @@ import { basename, dirname, resolve, toFileUrl } from "@std/path";
 import { parse } from "@std/dotenv/parse";
 import { crypto } from "@std/crypto";
 import { encodeHex } from "@std/encoding/hex";
-import { LOCAL_RUN_DEFAULTS, resolveModuleTests, TestExecutor, toSingleExecutionOptions } from "@glubean/runner";
-import type { ResolvedTest, SharedRunConfig } from "@glubean/runner";
-import { createStaticScanner, scan } from "@glubean/scanner";
-import type { BundleMetadata, FileMeta, ScanResult } from "@glubean/scanner";
+import { LOCAL_RUN_DEFAULTS, TestExecutor, toSingleExecutionOptions } from "@glubean/runner";
+import type { SharedRunConfig } from "@glubean/runner";
+import { createStaticScanner, extractFromSource, scan } from "@glubean/scanner";
+import type { BundleMetadata, ExportMeta, FileMeta, ScanResult } from "@glubean/scanner";
 import { DEFAULT_GENERATED_BY, MCP_PACKAGE_VERSION } from "./version.ts";
 
 type Vars = Record<string, string>;
@@ -139,12 +139,12 @@ async function buildMetadata(
 
 export async function discoverTestsFromFile(filePath: string): Promise<{
   fileUrl: string;
-  tests: ResolvedTest[];
+  tests: ExportMeta[];
 }> {
   const absolutePath = resolve(filePath);
   const fileUrl = toFileUrl(absolutePath).toString();
-  const module = await import(fileUrl);
-  const tests = resolveModuleTests(module);
+  const content = await Deno.readTextFile(absolutePath);
+  const tests = extractFromSource(content);
   return { fileUrl, tests };
 }
 
@@ -441,7 +441,11 @@ export async function runLocalTestsFromFile(args: {
     failFast: Boolean(args.stopOnFailure),
     concurrency: Math.max(1, args.concurrency ?? 1),
   };
-  const executor = TestExecutor.fromSharedConfig(shared);
+  const denoJsonPath = resolve(projectRoot, "deno.json");
+  const executor = TestExecutor.fromSharedConfig(shared, {
+    configPath: denoJsonPath,
+    cwd: projectRoot,
+  });
 
   const concurrency = shared.concurrency;
   const stopOnFailure = shared.failFast;


### PR DESCRIPTION
## Summary
- Replace `import()` with `extractFromSource()` in `discoverTestsFromFile()` — eliminates dependency on project's import map for test discovery
- Pass `configPath` and `cwd` to `TestExecutor` so subprocess resolves the project's `deno.json` correctly during execution
- Add `GLUBEAN_DEV_CONFIG` auto-detection in integration tests for local workspace development

## Test plan
- [x] 22 tests pass (15 integration + 7 unit): `deno test packages/mcp/`
- [x] Verified live via MCP tools: discover + run on simple-project fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)