### PR TITLE
chore(mcp): bump to 0.12.3

### DIFF
--- a/packages/mcp/deno.json
+++ b/packages/mcp/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/mcp",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean MCP server - run checks and fetch facts for AI agents",


### PR DESCRIPTION
## Summary
- Patch version bump for @glubean/mcp after import map fix (#63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)