### PR TITLE
fix(cli): resolve auth from .env.secrets and deno.json cloud config

### DIFF
--- a/packages/cli/commands/run.ts
+++ b/packages/cli/commands/run.ts
@@ -5,8 +5,8 @@ import {
   toSingleExecutionOptions,
 } from "@glubean/runner";
 import { basename, dirname, isAbsolute, relative, resolve, toFileUrl } from "@std/path";
-import { parse as parseDotenv } from "@std/dotenv/parse";
 import { loadConfig, mergeRunOptions, toSharedRunConfig } from "../lib/config.ts";
+import { loadEnvFile } from "../lib/env.ts";
 import { walk } from "@std/fs/walk";
 import { expandGlob } from "@std/fs/expand-glob";
 import { extractWithDeno } from "@glubean/scanner";
@@ -142,15 +142,6 @@ async function findProjectConfig(
   }
   // No deno.json found, use the start directory
   return { rootDir: startDir };
-}
-
-async function loadEnvFile(envPath: string): Promise<Record<string, string>> {
-  try {
-    const content = await Deno.readTextFile(envPath);
-    return parseDotenv(content);
-  } catch {
-    return {};
-  }
 }
 
 const DEFAULT_SKIP_DIRS = ["node_modules", ".git", "dist", "build", ".deno"];
@@ -1329,17 +1320,21 @@ export async function runCommand(
       project: options.project,
       apiUrl: options.apiUrl,
     };
-    const token = await resolveToken(authOpts);
-    const projectId = await resolveProjectId(authOpts);
-    const apiUrl = await resolveApiUrl(authOpts);
+    const sources = {
+      envFileVars: { ...envVars, ...secrets },
+      cloudConfig: glubeanConfig.cloud,
+    };
+    const token = await resolveToken(authOpts, sources);
+    const projectId = await resolveProjectId(authOpts, sources);
+    const apiUrl = await resolveApiUrl(authOpts, sources);
 
     if (!token) {
       console.log(
-        `${colors.yellow}No auth token found. Run 'glubean login' or set GLUBEAN_TOKEN.${colors.reset}`,
+        `${colors.yellow}No auth token found. Run 'glubean login', set GLUBEAN_TOKEN, or add it to .env.secrets.${colors.reset}`,
       );
     } else if (!projectId) {
       console.log(
-        `${colors.yellow}No project ID. Use --project or run 'glubean login'.${colors.reset}`,
+        `${colors.yellow}No project ID. Use --project, set in deno.json glubean.cloud, or run 'glubean login'.${colors.reset}`,
       );
     } else {
       await uploadToCloud(resultPayload, {

--- a/packages/cli/commands/sync.ts
+++ b/packages/cli/commands/sync.ts
@@ -15,7 +15,9 @@ import { walk } from "@std/fs/walk";
 import { type BundleMetadata, type FileMeta, scan } from "@glubean/scanner";
 import { buildMetadata } from "../metadata.ts";
 import { CLI_VERSION } from "../version.ts";
-import { DEFAULT_API_URL } from "../lib/constants.ts";
+import { resolveApiUrl, resolveProjectId, resolveToken } from "../lib/auth.ts";
+import { loadConfig } from "../lib/config.ts";
+import { loadProjectEnv } from "../lib/env.ts";
 
 const colors = {
   reset: "\x1b[0m",
@@ -308,25 +310,33 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
     `\n${colors.bold}${colors.blue}☁️  Glubean Sync${colors.reset}\n`,
   );
 
-  // Validate options
-  if (!options.project) {
-    console.log(`${colors.red}✗ Error: --project is required${colors.reset}`);
+  const dir = options.dir ? resolve(options.dir) : Deno.cwd();
+
+  // Resolve auth from all sources
+  const config = await loadConfig(dir);
+  const envFileVars = await loadProjectEnv(dir, config.run.envFile);
+  const sources = { envFileVars, cloudConfig: config.cloud };
+  const authOpts = {
+    token: options.token,
+    project: options.project,
+    apiUrl: options.apiUrl,
+  };
+
+  const projectId = await resolveProjectId(authOpts, sources);
+  if (!projectId) {
+    console.log(`${colors.red}✗ Error: No project ID found.${colors.reset}`);
     console.log(
-      `${colors.dim}  Usage: glubean sync --project <project-id>${colors.reset}\n`,
+      `${colors.dim}  Use --project, set GLUBEAN_PROJECT_ID, add to .env, or configure in deno.json glubean.cloud.${colors.reset}\n`,
     );
     Deno.exit(1);
   }
 
-  const dir = options.dir ? resolve(options.dir) : Deno.cwd();
   const version = options.version ||
     new Date().toISOString().replace(/[:.]/g, "-");
-  const apiUrl = (
-    options.apiUrl ||
-    Deno.env.get("GLUBEAN_API_URL") ||
-    DEFAULT_API_URL
-  ).replace(/\/$/, "");
+  const apiUrl = (await resolveApiUrl(authOpts, sources)).replace(/\/$/, "");
+  const token = await resolveToken(authOpts, sources);
 
-  console.log(`${colors.dim}Project:   ${colors.reset}${options.project}`);
+  console.log(`${colors.dim}Project:   ${colors.reset}${projectId}`);
   console.log(`${colors.dim}Version:   ${colors.reset}${version}`);
   console.log(`${colors.dim}Directory: ${colors.reset}${dir}`);
   console.log();
@@ -344,7 +354,7 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
 
   const metadata = await buildMetadata(scanResult, {
     generatedBy: `@glubean/cli@${CLI_VERSION}`,
-    projectId: options.project,
+    projectId,
     version,
   });
   const files = metadata.files;
@@ -399,10 +409,10 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
     // Step 4a: Initialize sync - get presigned URL
     console.log(`${colors.cyan}→ Initializing sync...${colors.reset}`);
     const initResult = await initSync(
-      options.project,
+      projectId,
       version,
       apiUrl,
-      options.token,
+      token ?? undefined,
     );
     console.log(
       `${colors.green}✓ Bundle ID: ${initResult.bundleId}${colors.reset}`,
@@ -416,12 +426,12 @@ export async function syncCommand(options: SyncOptions = {}): Promise<void> {
     // Step 4c: Complete sync - save metadata
     console.log(`${colors.cyan}→ Finalizing sync...${colors.reset}`);
     const completeResult = await completeSync(
-      options.project,
+      projectId,
       initResult.bundleId,
       syncTimestamp,
       metadata.files,
       apiUrl,
-      options.token,
+      token ?? undefined,
     );
     console.log(`${colors.green}✓ Sync finalized${colors.reset}`);
 

--- a/packages/cli/commands/trigger.ts
+++ b/packages/cli/commands/trigger.ts
@@ -7,7 +7,9 @@
  *   glubean trigger --project <id> --follow     # Tail logs until complete
  */
 
-import { DEFAULT_API_URL } from "../lib/constants.ts";
+import { resolveApiUrl, resolveProjectId, resolveToken } from "../lib/auth.ts";
+import { loadConfig } from "../lib/config.ts";
+import { loadProjectEnv } from "../lib/env.ts";
 
 const colors = {
   reset: "\x1b[0m",
@@ -276,24 +278,31 @@ export async function triggerCommand(
     `\n${colors.bold}${colors.blue}🚀 Glubean Trigger${colors.reset}\n`,
   );
 
-  // Validate options
-  if (!options.project) {
-    console.log(`${colors.red}✗ Error: --project is required${colors.reset}`);
+  // Resolve auth from all sources
+  const rootDir = Deno.cwd();
+  const config = await loadConfig(rootDir);
+  const envFileVars = await loadProjectEnv(rootDir, config.run.envFile);
+  const sources = { envFileVars, cloudConfig: config.cloud };
+  const authOpts = {
+    token: options.token,
+    project: options.project,
+    apiUrl: options.apiUrl,
+  };
+
+  const projectId = await resolveProjectId(authOpts, sources);
+  if (!projectId) {
+    console.log(`${colors.red}✗ Error: No project ID found.${colors.reset}`);
     console.log(
-      `${colors.dim}  Usage: glubean trigger --project <project-id>${colors.reset}\n`,
+      `${colors.dim}  Use --project, set GLUBEAN_PROJECT_ID, add to .env, or configure in deno.json glubean.cloud.${colors.reset}\n`,
     );
     Deno.exit(1);
   }
 
-  const apiUrl = (
-    options.apiUrl ||
-    Deno.env.get("GLUBEAN_API_URL") ||
-    DEFAULT_API_URL
-  ).replace(/\/$/, "");
+  const apiUrl = (await resolveApiUrl(authOpts, sources)).replace(/\/$/, "");
   const appUrl = apiUrl.replace("api.", "app.").replace(/\/$/, "");
-  const token = options.token || Deno.env.get("GLUBEAN_TOKEN");
+  const token = await resolveToken(authOpts, sources);
 
-  console.log(`${colors.dim}Project: ${colors.reset}${options.project}`);
+  console.log(`${colors.dim}Project: ${colors.reset}${projectId}`);
   if (options.bundle) {
     console.log(`${colors.dim}Bundle:  ${colors.reset}${options.bundle}`);
   } else {
@@ -308,9 +317,9 @@ export async function triggerCommand(
     // Create the run
     console.log(`${colors.cyan}→ Creating run...${colors.reset}`);
     const result = await createRun(
-      options.project,
+      projectId,
       apiUrl,
-      token,
+      token ?? undefined,
       options.bundle,
       options.job,
     );
@@ -333,7 +342,7 @@ export async function triggerCommand(
         `${colors.dim}─────────────────────────────────────${colors.reset}`,
       );
 
-      const finalStatus = await tailEvents(result.runId, apiUrl, token);
+      const finalStatus = await tailEvents(result.runId, apiUrl, token ?? undefined);
 
       console.log(
         `${colors.dim}─────────────────────────────────────${colors.reset}`,

--- a/packages/cli/lib/auth.ts
+++ b/packages/cli/lib/auth.ts
@@ -3,8 +3,10 @@
  *
  * Priority order:
  *   1. CLI flag (--token / --project / --api-url)
- *   2. Environment variable (GLUBEAN_TOKEN / GLUBEAN_PROJECT_ID / GLUBEAN_API_URL)
- *   3. ~/.glubean/credentials.json
+ *   2. System environment variable (GLUBEAN_TOKEN / GLUBEAN_PROJECT_ID / GLUBEAN_API_URL)
+ *   3. .env + .env.secrets file vars (project-level)
+ *   4. deno.json glubean.cloud config (projectId, apiUrl only — no token)
+ *   5. ~/.glubean/credentials.json (global fallback)
  */
 
 import { dirname, join } from "@std/path";
@@ -20,6 +22,17 @@ export interface AuthOptions {
   token?: string;
   project?: string;
   apiUrl?: string;
+}
+
+/**
+ * Additional auth sources from the project context.
+ * Passed by callers that have already loaded env files and config.
+ */
+export interface ProjectAuthSources {
+  /** Merged vars from .env + .env.secrets */
+  envFileVars?: Record<string, string>;
+  /** Cloud section from deno.json glubean config */
+  cloudConfig?: { apiUrl?: string; projectId?: string };
 }
 
 function getCredentialsPath(): string | null {
@@ -47,26 +60,58 @@ export async function writeCredentials(creds: Credentials): Promise<string> {
   return path;
 }
 
-export async function resolveToken(options: AuthOptions): Promise<string | null> {
+export async function resolveToken(
+  options: AuthOptions,
+  sources?: ProjectAuthSources,
+): Promise<string | null> {
+  // 1. CLI flag
   if (options.token) return options.token;
+  // 2. System env var
   const env = Deno.env.get("GLUBEAN_TOKEN");
   if (env) return env;
+  // 3. .env / .env.secrets
+  const fileVar = sources?.envFileVars?.["GLUBEAN_TOKEN"];
+  if (fileVar) return fileVar;
+  // 4. deno.json cloud — no token (security: never commit tokens)
+  // 5. ~/.glubean/credentials.json
   const creds = await readCredentials();
   return creds?.token ?? null;
 }
 
-export async function resolveProjectId(options: AuthOptions): Promise<string | null> {
+export async function resolveProjectId(
+  options: AuthOptions,
+  sources?: ProjectAuthSources,
+): Promise<string | null> {
+  // 1. CLI flag
   if (options.project) return options.project;
+  // 2. System env var
   const env = Deno.env.get("GLUBEAN_PROJECT_ID");
   if (env) return env;
+  // 3. .env / .env.secrets
+  const fileVar = sources?.envFileVars?.["GLUBEAN_PROJECT_ID"];
+  if (fileVar) return fileVar;
+  // 4. deno.json cloud config
+  if (sources?.cloudConfig?.projectId) return sources.cloudConfig.projectId;
+  // 5. ~/.glubean/credentials.json
   const creds = await readCredentials();
   return creds?.projectId ?? null;
 }
 
-export async function resolveApiUrl(options: AuthOptions): Promise<string> {
+export async function resolveApiUrl(
+  options: AuthOptions,
+  sources?: ProjectAuthSources,
+): Promise<string> {
+  // 1. CLI flag
+  if (options.apiUrl) return options.apiUrl;
+  // 2. System env var
   const env = Deno.env.get("GLUBEAN_API_URL");
   if (env) return env;
-  if (options.apiUrl) return options.apiUrl;
+  // 3. .env / .env.secrets
+  const fileVar = sources?.envFileVars?.["GLUBEAN_API_URL"];
+  if (fileVar) return fileVar;
+  // 4. deno.json cloud config
+  if (sources?.cloudConfig?.apiUrl) return sources.cloudConfig.apiUrl;
+  // 5. ~/.glubean/credentials.json
   const creds = await readCredentials();
   return creds?.apiUrl ?? DEFAULT_API_URL;
 }

--- a/packages/cli/lib/auth_test.ts
+++ b/packages/cli/lib/auth_test.ts
@@ -155,13 +155,13 @@ Deno.test("resolveProjectId: returns null when nothing available", async () => {
 
 // ── resolveApiUrl ──
 
-Deno.test("resolveApiUrl: env takes priority", async () => {
+Deno.test("resolveApiUrl: flag takes priority over env", async () => {
   await withTempHome(async () => {
     await writeCredentials({ token: "gb_x", apiUrl: "https://file.api.com" });
     Deno.env.set("GLUBEAN_API_URL", "https://env.api.com");
 
     const url = await resolveApiUrl({ apiUrl: "https://flag.api.com" });
-    assertEquals(url, "https://env.api.com");
+    assertEquals(url, "https://flag.api.com");
   });
 });
 
@@ -185,5 +185,51 @@ Deno.test("resolveApiUrl: defaults to DEFAULT_API_URL", async () => {
   await withTempHome(async () => {
     const url = await resolveApiUrl({});
     assertEquals(url, DEFAULT_API_URL);
+  });
+});
+
+// ── ProjectAuthSources tests ──
+
+Deno.test("resolveToken: envFileVars used when no flag or system env", async () => {
+  await withTempHome(async () => {
+    const sources = { envFileVars: { GLUBEAN_TOKEN: "gb_from_dotenv" } };
+    const token = await resolveToken({}, sources);
+    assertEquals(token, "gb_from_dotenv");
+  });
+});
+
+Deno.test("resolveToken: system env takes priority over envFileVars", async () => {
+  await withTempHome(async () => {
+    Deno.env.set("GLUBEAN_TOKEN", "gb_system");
+    const sources = { envFileVars: { GLUBEAN_TOKEN: "gb_from_dotenv" } };
+    const token = await resolveToken({}, sources);
+    assertEquals(token, "gb_system");
+  });
+});
+
+Deno.test("resolveProjectId: cloudConfig used when no flag, env, or envFileVars", async () => {
+  await withTempHome(async () => {
+    const sources = { cloudConfig: { projectId: "proj_from_config" } };
+    const id = await resolveProjectId({}, sources);
+    assertEquals(id, "proj_from_config");
+  });
+});
+
+Deno.test("resolveProjectId: envFileVars takes priority over cloudConfig", async () => {
+  await withTempHome(async () => {
+    const sources = {
+      envFileVars: { GLUBEAN_PROJECT_ID: "proj_from_dotenv" },
+      cloudConfig: { projectId: "proj_from_config" },
+    };
+    const id = await resolveProjectId({}, sources);
+    assertEquals(id, "proj_from_dotenv");
+  });
+});
+
+Deno.test("resolveApiUrl: cloudConfig used when no flag, env, or envFileVars", async () => {
+  await withTempHome(async () => {
+    const sources = { cloudConfig: { apiUrl: "https://config.api.com" } };
+    const url = await resolveApiUrl({}, sources);
+    assertEquals(url, "https://config.api.com");
   });
 });

--- a/packages/cli/lib/config.ts
+++ b/packages/cli/lib/config.ts
@@ -78,16 +78,24 @@ export interface GlubeanRedactionConfigInput {
   replacementFormat?: "simple" | "labeled" | "partial";
 }
 
+/** Cloud connection config (non-secret fields only). */
+export interface GlubeanCloudConfigInput {
+  projectId?: string;
+  apiUrl?: string;
+}
+
 /** Fully resolved top-level config. */
 export interface GlubeanConfig {
   run: GlubeanRunConfig;
   redaction: RedactionConfig;
+  cloud?: GlubeanCloudConfigInput;
 }
 
 /** Partial top-level config as read from a file. */
 export interface GlubeanConfigInput {
   run?: GlubeanRunConfigInput;
   redaction?: GlubeanRedactionConfigInput;
+  cloud?: GlubeanCloudConfigInput;
 }
 
 // ── Defaults ─────────────────────────────────────────────────────────────────
@@ -199,6 +207,11 @@ export function mergeConfigInputs(
         ],
       };
     }
+  }
+
+  // ── Cloud section (shallow merge, scalars override) ─────────────────────
+  if (base.cloud || overlay.cloud) {
+    merged.cloud = { ...base.cloud, ...overlay.cloud };
   }
 
   return merged;
@@ -318,6 +331,7 @@ export async function loadConfig(
   return {
     run: resolvedRun,
     redaction: resolvedRedaction,
+    cloud: accumulated.cloud,
   };
 }
 

--- a/packages/cli/lib/config_test.ts
+++ b/packages/cli/lib/config_test.ts
@@ -359,3 +359,36 @@ Deno.test("mergeRunOptions: envFile override", () => {
   });
   assertEquals(result.envFile, ".env.staging");
 });
+
+// ═════════════════════════════════════════════════════════════════════════════
+// cloud config
+// ═════════════════════════════════════════════════════════════════════════════
+
+Deno.test("loadConfig: cloud section from deno.json", async () => {
+  await withTempDir(
+    {
+      "deno.json": JSON.stringify({
+        glubean: {
+          cloud: { projectId: "proj_abc", apiUrl: "https://custom.api.com" },
+        },
+      }),
+    },
+    async (dir) => {
+      const config = await loadConfig(dir);
+      assertEquals(config.cloud?.projectId, "proj_abc");
+      assertEquals(config.cloud?.apiUrl, "https://custom.api.com");
+    },
+  );
+});
+
+Deno.test("mergeConfigInputs: cloud section merges", () => {
+  const base: GlubeanConfigInput = {
+    cloud: { projectId: "proj_a" },
+  };
+  const overlay: GlubeanConfigInput = {
+    cloud: { apiUrl: "https://overlay.api.com" },
+  };
+  const merged = mergeConfigInputs(base, overlay);
+  assertEquals(merged.cloud?.projectId, "proj_a");
+  assertEquals(merged.cloud?.apiUrl, "https://overlay.api.com");
+});

--- a/packages/cli/lib/env.ts
+++ b/packages/cli/lib/env.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared .env file loading for the Glubean CLI.
+ *
+ * Extracted from run.ts to be reusable by auth resolution,
+ * sync, trigger, and other commands that need project-level env vars.
+ */
+
+import { resolve } from "@std/path";
+import { parse as parseDotenv } from "@std/dotenv/parse";
+
+/**
+ * Load a single .env file and return its key-value pairs.
+ * Returns an empty object if the file doesn't exist or can't be read.
+ */
+export async function loadEnvFile(
+  envPath: string,
+): Promise<Record<string, string>> {
+  try {
+    const content = await Deno.readTextFile(envPath);
+    return parseDotenv(content);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Load `.env` + `.env.secrets` from a project root directory.
+ *
+ * The secrets file path follows the env file name:
+ *   `.env` → `.env.secrets`
+ *   `.env.staging` → `.env.staging.secrets`
+ *
+ * Secrets overlay env vars (later values win).
+ *
+ * @param rootDir  - Project root directory.
+ * @param envFileName - Base env file name (default: ".env").
+ * @returns Merged key-value pairs from both files.
+ */
+export async function loadProjectEnv(
+  rootDir: string,
+  envFileName = ".env",
+): Promise<Record<string, string>> {
+  const envPath = resolve(rootDir, envFileName);
+  const secretsPath = resolve(rootDir, `${envFileName}.secrets`);
+
+  const envVars = await loadEnvFile(envPath);
+  const secrets = await loadEnvFile(secretsPath);
+
+  return { ...envVars, ...secrets };
+}

--- a/packages/cli/lib/env.ts
+++ b/packages/cli/lib/env.ts
@@ -18,7 +18,11 @@ export async function loadEnvFile(
   try {
     const content = await Deno.readTextFile(envPath);
     return parseDotenv(content);
-  } catch {
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return {};
+    }
+    console.warn(`Warning: Could not read env file ${envPath}: ${(error as Error).message}`);
     return {};
   }
 }

--- a/packages/cli/lib/env_test.ts
+++ b/packages/cli/lib/env_test.ts
@@ -1,0 +1,55 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { loadEnvFile, loadProjectEnv } from "./env.ts";
+
+Deno.test("loadEnvFile: parses key=value pairs", async () => {
+  const tmp = await Deno.makeTempDir();
+  const envPath = join(tmp, ".env");
+  await Deno.writeTextFile(envPath, "FOO=bar\nBAZ=qux\n");
+
+  const vars = await loadEnvFile(envPath);
+  assertEquals(vars.FOO, "bar");
+  assertEquals(vars.BAZ, "qux");
+
+  await Deno.remove(tmp, { recursive: true });
+});
+
+Deno.test("loadEnvFile: returns empty for missing file", async () => {
+  const vars = await loadEnvFile("/nonexistent/.env.nope");
+  assertEquals(vars, {});
+});
+
+Deno.test("loadProjectEnv: merges .env and .env.secrets", async () => {
+  const tmp = await Deno.makeTempDir();
+  await Deno.writeTextFile(join(tmp, ".env"), "A=1\nB=2\n");
+  await Deno.writeTextFile(join(tmp, ".env.secrets"), "B=override\nC=3\n");
+
+  const vars = await loadProjectEnv(tmp);
+  assertEquals(vars.A, "1");
+  assertEquals(vars.B, "override"); // secrets wins
+  assertEquals(vars.C, "3");
+
+  await Deno.remove(tmp, { recursive: true });
+});
+
+Deno.test("loadProjectEnv: custom envFileName", async () => {
+  const tmp = await Deno.makeTempDir();
+  await Deno.writeTextFile(join(tmp, ".env.staging"), "STAGE=true\n");
+  await Deno.writeTextFile(
+    join(tmp, ".env.staging.secrets"),
+    "TOKEN=secret\n",
+  );
+
+  const vars = await loadProjectEnv(tmp, ".env.staging");
+  assertEquals(vars.STAGE, "true");
+  assertEquals(vars.TOKEN, "secret");
+
+  await Deno.remove(tmp, { recursive: true });
+});
+
+Deno.test("loadProjectEnv: missing files return empty", async () => {
+  const tmp = await Deno.makeTempDir();
+  const vars = await loadProjectEnv(tmp);
+  assertEquals(vars, {});
+  await Deno.remove(tmp, { recursive: true });
+});


### PR DESCRIPTION
## Summary

- CLI commands (`run --upload`, `sync`, `trigger`) now resolve credentials from a 5-level priority chain:
  1. CLI flag → 2. System env var → 3. `.env` + `.env.secrets` → 4. `deno.json` cloud config → 5. `~/.glubean/credentials.json`
- Extract shared `loadEnvFile`/`loadProjectEnv` to `lib/env.ts` (previously duplicated in run.ts, worker, mcp)
- Add `cloud` section to config types (`GlubeanCloudConfigInput`) for non-secret project settings in `deno.json`
- Replace inline auth resolution in `sync.ts` and `trigger.ts` with shared `auth.ts` functions
- Fix `resolveApiUrl` priority bug: CLI flag now correctly wins over env var (consistent with resolveToken/resolveProjectId)

## Test plan

- [x] 100/100 CLI tests pass (`deno test -A packages/cli/`)
- [x] New tests for `loadEnvFile`, `loadProjectEnv`, `ProjectAuthSources`, and cloud config merge
- [ ] Manual: `.env.secrets` with `GLUBEAN_TOKEN=gpt_xxx` → `glubean run --upload` succeeds
- [ ] Manual: `deno.json` with `"glubean": { "cloud": { "projectId": "xxx" } }` → auto-used
- [ ] Manual: System `GLUBEAN_TOKEN` env var takes priority over `.env.secrets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)