### PR TITLE
fix: move ky dependency from runner to SDK

### DIFF
--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -14,7 +14,6 @@
   "imports": {
     "@glubean/sdk": "jsr:@glubean/sdk@^0.12.0",
     "@std/cli": "jsr:@std/cli@^1.0.0",
-    "@std/assert": "jsr:@std/assert@^1.0.0",
-    "ky": "npm:ky@^1.14.0"
+    "@std/assert": "jsr:@std/assert@^1.0.0"
   }
 }

--- a/packages/runner/harness.ts
+++ b/packages/runner/harness.ts
@@ -7,7 +7,7 @@
  */
 
 import { parseArgs } from "@std/cli/parse-args";
-import ky from "ky";
+import { ky } from "@glubean/sdk";
 import {
   classifyHostnameBlockReason,
   classifyIpBlockReason,

--- a/packages/sdk/deno.json
+++ b/packages/sdk/deno.json
@@ -12,7 +12,8 @@
   "description": "Glubean SDK - Type definitions and helpers for writing API tests",
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.0",
-    "@std/yaml": "jsr:@std/yaml@^1.0.0"
+    "@std/yaml": "jsr:@std/yaml@^1.0.0",
+    "ky": "npm:ky@^1.14.0"
   },
   "publish": {
     "exclude": [

--- a/packages/sdk/mod.ts
+++ b/packages/sdk/mod.ts
@@ -1514,3 +1514,8 @@ export { definePlugin } from "./plugin.ts";
 // Re-export assertion utilities
 export { Expectation, ExpectFailError } from "./expect.ts";
 export type { AssertEmitter, AssertionEmission, CustomMatchers, MatcherFn, MatcherResult } from "./expect.ts";
+
+// Re-export ky — SDK wraps ky for HTTP, so it's a first-class dependency.
+// This ensures runner/harness can import ky via SDK without requiring users
+// to declare ky in their own deno.json.
+export { default as ky } from "ky";


### PR DESCRIPTION
## Summary
- SDK now declares `ky` as a first-class dependency and re-exports it (`export { default as ky } from "ky"`)
- Runner harness imports ky from `@glubean/sdk` instead of directly from `"ky"`
- Runner's own ky dependency removed (resolved transitively via SDK)

**Problem:** When CLI runs tests in external projects, the harness subprocess resolves deps from the user's `deno.json`. If the user doesn't declare `ky`, the import fails silently. Every user hits this.

**Fix:** SDK → JSR → ky resolves correctly regardless of user's project config. No more `GLUBEAN_DEV_CONFIG` workaround needed.

## Test plan
- [x] `deno check packages/sdk/mod.ts` passes
- [x] `deno check packages/runner/harness.ts` passes
- [ ] Run collections tests without `GLUBEAN_DEV_CONFIG` after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)