### PR TITLE
feat: add metric threshold evaluation (M1)

### DIFF
--- a/packages/cli/commands/run.ts
+++ b/packages/cli/commands/run.ts
@@ -1,5 +1,7 @@
 import {
+  evaluateThresholds,
   type ExecutionEvent,
+  MetricCollector,
   normalizePositiveTimeoutMs,
   TestExecutor,
   toSingleExecutionOptions,
@@ -676,6 +678,9 @@ export async function runCommand(
   // Collect all events per test (for result JSON and rich summary)
   const collectedRuns: CollectedTestRun[] = [];
 
+  // Collect metric data points for threshold evaluation
+  const metricCollector = new MetricCollector();
+
   // Aggregate summary stats across all tests
   const runStats: RunSummaryStats = {
     httpRequestTotal: 0,
@@ -1055,6 +1060,7 @@ export async function runCommand(
         }
 
         case "metric": {
+          metricCollector.add(event.name, event.value);
           const unit = event.unit ? ` ${event.unit}` : "";
           const tagStr = event.tags
             ? ` ${colors.dim}{${
@@ -1225,6 +1231,31 @@ export async function runCommand(
     );
   }
 
+  // ── Threshold evaluation ──────────────────────────────────────────────────
+  let thresholdSummary: import("@glubean/sdk").ThresholdSummary | undefined;
+  if (glubeanConfig.thresholds && Object.keys(glubeanConfig.thresholds).length > 0) {
+    thresholdSummary = evaluateThresholds(glubeanConfig.thresholds, metricCollector);
+    const { results: thresholdResults, pass: allPass } = thresholdSummary;
+
+    if (thresholdResults.length > 0) {
+      console.log(
+        `${colors.bold}Thresholds:${colors.reset}`,
+      );
+      for (const r of thresholdResults) {
+        const icon = r.pass ? `${colors.green}✓${colors.reset}` : `${colors.red}✗${colors.reset}`;
+        const actualStr = Number.isNaN(r.actual) ? "N/A" : String(r.actual);
+        console.log(
+          `  ${icon} ${r.metric}.${r.aggregation} ... ${actualStr} ${r.threshold}`,
+        );
+      }
+      const tPassed = thresholdResults.filter((r) => r.pass).length;
+      const statusColor = allPass ? colors.green : colors.red;
+      console.log(
+        `  ${statusColor}${tPassed}/${thresholdResults.length} passed${colors.reset}`,
+      );
+    }
+  }
+
   console.log();
 
   // Write log file if enabled (single-file: <file>.log, multi-file: glubean-run.log in cwd)
@@ -1358,6 +1389,7 @@ export async function runCommand(
       durationMs: r.durationMs,
       events: r.events,
     })),
+    ...(thresholdSummary && { thresholds: thresholdSummary }),
   };
   const resultJson = JSON.stringify(resultPayload, null, 2);
 
@@ -1500,7 +1532,7 @@ export async function runCommand(
     }
   }
 
-  if (failed > 0) {
+  if (failed > 0 || (thresholdSummary && !thresholdSummary.pass)) {
     Deno.exit(1);
   }
 }

--- a/packages/cli/lib/config.ts
+++ b/packages/cli/lib/config.ts
@@ -19,6 +19,7 @@ import { DEFAULT_CONFIG } from "@glubean/redaction";
 import type { RedactionConfig } from "@glubean/redaction";
 import { LOCAL_RUN_DEFAULTS } from "@glubean/runner";
 import type { SharedRunConfig } from "@glubean/runner";
+import type { ThresholdConfig } from "@glubean/sdk";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -90,6 +91,7 @@ export interface GlubeanConfig {
   run: GlubeanRunConfig;
   redaction: RedactionConfig;
   cloud?: GlubeanCloudConfigInput;
+  thresholds?: ThresholdConfig;
 }
 
 /** Partial top-level config as read from a file. */
@@ -97,6 +99,7 @@ export interface GlubeanConfigInput {
   run?: GlubeanRunConfigInput;
   redaction?: GlubeanRedactionConfigInput;
   cloud?: GlubeanCloudConfigInput;
+  thresholds?: ThresholdConfig;
 }
 
 // ── Defaults ─────────────────────────────────────────────────────────────────
@@ -215,6 +218,11 @@ export function mergeConfigInputs(
     merged.cloud = { ...base.cloud, ...overlay.cloud };
   }
 
+  // ── Thresholds section (shallow merge, later rules win per metric key) ──
+  if (base.thresholds || overlay.thresholds) {
+    merged.thresholds = { ...base.thresholds, ...overlay.thresholds };
+  }
+
   return merged;
 }
 
@@ -276,7 +284,7 @@ function resolveRedactionConfig(
 
 // ── Validation ───────────────────────────────────────────────────────────────
 
-const KNOWN_TOP_KEYS = new Set(["run", "redaction", "cloud"]);
+const KNOWN_TOP_KEYS = new Set(["run", "redaction", "cloud", "thresholds"]);
 const KNOWN_RUN_KEYS = new Set(Object.keys(RUN_DEFAULTS));
 const KNOWN_REDACTION_KEYS = new Set([
   "sensitiveKeys",
@@ -391,6 +399,7 @@ export async function loadConfig(
     run: resolvedRun,
     redaction: resolvedRedaction,
     cloud: accumulated.cloud,
+    thresholds: accumulated.thresholds,
   };
 }
 

--- a/packages/runner/mod.ts
+++ b/packages/runner/mod.ts
@@ -33,3 +33,5 @@ export {
   resolveModuleTests,
 } from "./resolve.ts";
 export type { ResolvedTest } from "./resolve.ts";
+
+export { aggregate, evaluateThresholds, MetricCollector, parseExpression } from "./thresholds.ts";

--- a/packages/runner/thresholds.ts
+++ b/packages/runner/thresholds.ts
@@ -1,0 +1,191 @@
+/**
+ * Metric threshold evaluator.
+ *
+ * Collects metric data points during a run, then evaluates user-defined
+ * thresholds against aggregated values (avg, min, max, percentiles, count).
+ *
+ * @module
+ */
+
+import type {
+  MetricThresholdRules,
+  ThresholdAggregation,
+  ThresholdConfig,
+  ThresholdExpression,
+  ThresholdResult,
+  ThresholdSummary,
+} from "@glubean/sdk";
+
+// ── Metric Collector ──────────────────────────────────────────────────────────
+
+/**
+ * Collects raw metric values during a run, grouped by metric name.
+ * Call `add()` for each metric event, then `getValues()` to retrieve.
+ */
+export class MetricCollector {
+  private data = new Map<string, number[]>();
+
+  /** Record a single metric data point. */
+  add(name: string, value: number): void {
+    const arr = this.data.get(name);
+    if (arr) {
+      arr.push(value);
+    } else {
+      this.data.set(name, [value]);
+    }
+  }
+
+  /** Get all recorded values for a metric (empty array if none). */
+  getValues(name: string): number[] {
+    return this.data.get(name) ?? [];
+  }
+
+  /** Get all metric names that have data. */
+  getNames(): string[] {
+    return [...this.data.keys()];
+  }
+}
+
+// ── Aggregation ───────────────────────────────────────────────────────────────
+
+/** Compute a percentile from a sorted array (nearest-rank method). */
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+/** Compute an aggregation over a set of values. */
+export function aggregate(
+  values: number[],
+  agg: ThresholdAggregation,
+): number {
+  if (values.length === 0) return 0;
+
+  switch (agg) {
+    case "count":
+      return values.length;
+    case "avg":
+      return values.reduce((a, b) => a + b, 0) / values.length;
+    case "min":
+      return Math.min(...values);
+    case "max":
+      return Math.max(...values);
+    case "p50":
+    case "p90":
+    case "p95":
+    case "p99": {
+      const sorted = [...values].sort((a, b) => a - b);
+      const p = parseInt(agg.slice(1), 10);
+      return percentile(sorted, p);
+    }
+  }
+}
+
+// ── Expression Parsing ────────────────────────────────────────────────────────
+
+interface ParsedExpression {
+  operator: "<" | "<=";
+  value: number;
+}
+
+/** Parse a threshold expression like "<200" or "<=500". */
+export function parseExpression(expr: ThresholdExpression): ParsedExpression | null {
+  const match = expr.match(/^(<=?)\s*(-?\d+(?:\.\d+)?)$/);
+  if (!match) return null;
+  return {
+    operator: match[1] as "<" | "<=",
+    value: parseFloat(match[2]),
+  };
+}
+
+/** Evaluate whether an actual value passes a threshold expression. */
+function passes(actual: number, expr: ParsedExpression): boolean {
+  return expr.operator === "<" ? actual < expr.value : actual <= expr.value;
+}
+
+// ── Threshold Evaluation ──────────────────────────────────────────────────────
+
+/** Normalize shorthand string to full rules object. */
+function normalizeRules(
+  input: MetricThresholdRules | ThresholdExpression,
+): MetricThresholdRules {
+  if (typeof input === "string") {
+    return { avg: input };
+  }
+  return input;
+}
+
+const VALID_AGGREGATIONS = new Set<ThresholdAggregation>([
+  "avg",
+  "min",
+  "max",
+  "p50",
+  "p90",
+  "p95",
+  "p99",
+  "count",
+]);
+
+/**
+ * Evaluate all thresholds against collected metric data.
+ *
+ * @param config - User-defined threshold configuration
+ * @param collector - MetricCollector with recorded data points
+ * @returns Summary with individual results and overall pass/fail
+ */
+export function evaluateThresholds(
+  config: ThresholdConfig,
+  collector: MetricCollector,
+): ThresholdSummary {
+  const results: ThresholdResult[] = [];
+
+  for (const [metricName, rawRules] of Object.entries(config)) {
+    const rules = normalizeRules(rawRules);
+    const values = collector.getValues(metricName);
+
+    for (const [aggKey, expr] of Object.entries(rules)) {
+      const agg = aggKey as ThresholdAggregation;
+      if (!VALID_AGGREGATIONS.has(agg) || !expr) continue;
+
+      const parsed = parseExpression(expr);
+      if (!parsed) {
+        // Invalid expression — treat as fail
+        results.push({
+          metric: metricName,
+          aggregation: agg,
+          threshold: expr,
+          actual: NaN,
+          pass: false,
+        });
+        continue;
+      }
+
+      if (values.length === 0) {
+        // No data for this metric — skip (not a failure)
+        results.push({
+          metric: metricName,
+          aggregation: agg,
+          threshold: expr,
+          actual: 0,
+          pass: true,
+        });
+        continue;
+      }
+
+      const actual = aggregate(values, agg);
+      results.push({
+        metric: metricName,
+        aggregation: agg,
+        threshold: expr,
+        actual: Math.round(actual * 100) / 100,
+        pass: passes(actual, parsed),
+      });
+    }
+  }
+
+  return {
+    results,
+    pass: results.every((r) => r.pass),
+  };
+}

--- a/packages/runner/thresholds_test.ts
+++ b/packages/runner/thresholds_test.ts
@@ -1,0 +1,168 @@
+import { assertEquals } from "@std/assert";
+import { aggregate, evaluateThresholds, MetricCollector, parseExpression } from "./thresholds.ts";
+
+// ── parseExpression ──────────────────────────────────────────────────────────
+
+Deno.test("parseExpression - parses '<200'", () => {
+  const result = parseExpression("<200");
+  assertEquals(result, { operator: "<", value: 200 });
+});
+
+Deno.test("parseExpression - parses '<=500'", () => {
+  const result = parseExpression("<=500");
+  assertEquals(result, { operator: "<=", value: 500 });
+});
+
+Deno.test("parseExpression - parses '<0.01'", () => {
+  const result = parseExpression("<0.01");
+  assertEquals(result, { operator: "<", value: 0.01 });
+});
+
+Deno.test("parseExpression - returns null for invalid", () => {
+  assertEquals(parseExpression(">200"), null);
+  assertEquals(parseExpression("abc"), null);
+  assertEquals(parseExpression(""), null);
+});
+
+// ── aggregate ────────────────────────────────────────────────────────────────
+
+Deno.test("aggregate - avg", () => {
+  assertEquals(aggregate([10, 20, 30], "avg"), 20);
+});
+
+Deno.test("aggregate - min/max", () => {
+  assertEquals(aggregate([10, 20, 30], "min"), 10);
+  assertEquals(aggregate([10, 20, 30], "max"), 30);
+});
+
+Deno.test("aggregate - count", () => {
+  assertEquals(aggregate([10, 20, 30], "count"), 3);
+});
+
+Deno.test("aggregate - p95 with 100 values", () => {
+  const values = Array.from({ length: 100 }, (_, i) => i + 1);
+  const result = aggregate(values, "p95");
+  assertEquals(result, 95);
+});
+
+Deno.test("aggregate - p50", () => {
+  const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  const result = aggregate(values, "p50");
+  assertEquals(result, 5);
+});
+
+Deno.test("aggregate - empty array returns 0", () => {
+  assertEquals(aggregate([], "avg"), 0);
+  assertEquals(aggregate([], "p95"), 0);
+});
+
+// ── MetricCollector ──────────────────────────────────────────────────────────
+
+Deno.test("MetricCollector - collects and retrieves values", () => {
+  const c = new MetricCollector();
+  c.add("latency", 100);
+  c.add("latency", 200);
+  c.add("errors", 1);
+  assertEquals(c.getValues("latency"), [100, 200]);
+  assertEquals(c.getValues("errors"), [1]);
+  assertEquals(c.getValues("unknown"), []);
+  assertEquals(c.getNames().sort(), ["errors", "latency"]);
+});
+
+// ── evaluateThresholds ───────────────────────────────────────────────────────
+
+Deno.test("evaluateThresholds - all pass", () => {
+  const c = new MetricCollector();
+  for (const v of [50, 100, 150]) c.add("http_duration_ms", v);
+
+  const result = evaluateThresholds(
+    { http_duration_ms: { avg: "<200", max: "<500" } },
+    c,
+  );
+
+  assertEquals(result.pass, true);
+  assertEquals(result.results.length, 2);
+  assertEquals(result.results[0].pass, true);
+  assertEquals(result.results[1].pass, true);
+});
+
+Deno.test("evaluateThresholds - threshold violated", () => {
+  const c = new MetricCollector();
+  for (const v of [100, 200, 300, 400, 500]) c.add("latency", v);
+
+  const result = evaluateThresholds(
+    { latency: { avg: "<200" } },
+    c,
+  );
+
+  assertEquals(result.pass, false);
+  assertEquals(result.results[0].pass, false);
+  assertEquals(result.results[0].actual, 300);
+});
+
+Deno.test("evaluateThresholds - shorthand string expands to avg", () => {
+  const c = new MetricCollector();
+  c.add("error_rate", 0.005);
+
+  const result = evaluateThresholds(
+    { error_rate: "<0.01" },
+    c,
+  );
+
+  assertEquals(result.pass, true);
+  assertEquals(result.results[0].aggregation, "avg");
+});
+
+Deno.test("evaluateThresholds - no data for metric is a pass", () => {
+  const c = new MetricCollector();
+
+  const result = evaluateThresholds(
+    { missing_metric: { avg: "<100" } },
+    c,
+  );
+
+  assertEquals(result.pass, true);
+  assertEquals(result.results[0].pass, true);
+});
+
+Deno.test("evaluateThresholds - invalid expression is a fail", () => {
+  const c = new MetricCollector();
+  c.add("latency", 100);
+
+  const result = evaluateThresholds(
+    { latency: { avg: ">200" } },
+    c,
+  );
+
+  assertEquals(result.pass, false);
+  assertEquals(result.results[0].pass, false);
+});
+
+Deno.test("evaluateThresholds - <= operator", () => {
+  const c = new MetricCollector();
+  c.add("latency", 200);
+
+  const pass = evaluateThresholds({ latency: { max: "<=200" } }, c);
+  assertEquals(pass.pass, true);
+
+  const fail = evaluateThresholds({ latency: { max: "<200" } }, c);
+  assertEquals(fail.pass, false);
+});
+
+Deno.test("evaluateThresholds - multiple metrics", () => {
+  const c = new MetricCollector();
+  c.add("latency", 100);
+  c.add("latency", 200);
+  c.add("errors", 3);
+
+  const result = evaluateThresholds(
+    {
+      latency: { avg: "<200", max: "<300" },
+      errors: { max: "<5" },
+    },
+    c,
+  );
+
+  assertEquals(result.pass, true);
+  assertEquals(result.results.length, 3);
+});

--- a/packages/sdk/types.ts
+++ b/packages/sdk/types.ts
@@ -1606,6 +1606,88 @@ export interface MetricOptions {
   tags?: Record<string, string>;
 }
 
+// ── Metric Thresholds ─────────────────────────────────────────────────────────
+
+/**
+ * Aggregation function for threshold evaluation.
+ *
+ * - `avg`, `min`, `max`: basic statistics
+ * - `p50`, `p90`, `p95`, `p99`: percentiles
+ * - `count`: total number of data points
+ */
+export type ThresholdAggregation =
+  | "avg"
+  | "min"
+  | "max"
+  | "p50"
+  | "p90"
+  | "p95"
+  | "p99"
+  | "count";
+
+/**
+ * A single threshold rule: `"<200"` or `"<=500"`.
+ *
+ * The string format is: `operator + number`, where operator is `<` or `<=`.
+ */
+export type ThresholdExpression = string;
+
+/**
+ * Per-metric threshold rules keyed by aggregation function.
+ *
+ * @example
+ * ```ts
+ * { p95: "<200", avg: "<100", max: "<2000" }
+ * ```
+ */
+export type MetricThresholdRules = Partial<
+  Record<ThresholdAggregation, ThresholdExpression>
+>;
+
+/**
+ * Threshold configuration: metric name → rules (or shorthand string for avg).
+ *
+ * @example
+ * ```ts
+ * {
+ *   thresholds: {
+ *     "http_duration_ms": { p95: "<200", avg: "<100" },
+ *     "error_rate": "<0.01",  // shorthand for { avg: "<0.01" }
+ *   }
+ * }
+ * ```
+ */
+export type ThresholdConfig = Record<
+  string,
+  MetricThresholdRules | ThresholdExpression
+>;
+
+/**
+ * Result of evaluating a single threshold rule.
+ */
+export interface ThresholdResult {
+  /** Metric key (e.g., "http_duration_ms") */
+  metric: string;
+  /** Aggregation function used (e.g., "p95") */
+  aggregation: ThresholdAggregation;
+  /** The threshold expression (e.g., "<200") */
+  threshold: ThresholdExpression;
+  /** The actual computed value */
+  actual: number;
+  /** Whether the threshold was met */
+  pass: boolean;
+}
+
+/**
+ * Summary of all threshold evaluations for a run.
+ */
+export interface ThresholdSummary {
+  /** All individual threshold results */
+  results: ThresholdResult[];
+  /** True if all thresholds passed */
+  pass: boolean;
+}
+
 /**
  * Options for `ctx.pollUntil()`.
  */


### PR DESCRIPTION
## Summary
- SDK types: ThresholdConfig, ThresholdResult, ThresholdSummary
- Runner: MetricCollector + evaluateThresholds (avg/min/max/p50-p99/count)
- CLI: collect metrics during run, evaluate after completion, print results, exit(1) on violation
- Results included in result JSON and cloud upload payload
- 18 unit tests for evaluator

## Configuration
```json
{
  "glubean": {
    "thresholds": {
      "http_duration_ms": { "p95": "<200", "avg": "<100" },
      "error_rate": "<0.01"
    }
  }
}
```

## Test plan
- [x] 18 unit tests pass (parseExpression, aggregate, MetricCollector, evaluateThresholds)
- [x] Type-checks pass (runner, CLI)
- [ ] Manual: add thresholds to a project config, run tests, verify terminal output

🤖 Generated with [Claude Code](https://claude.com/claude-code)