### PR TITLE
fix: merge harness internal deps into consumer config

### DIFF
--- a/packages/auth/deno.json
+++ b/packages/auth/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/auth",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",

--- a/packages/graphql/deno.json
+++ b/packages/graphql/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/graphql",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts"

--- a/packages/mcp/deno.json
+++ b/packages/mcp/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/mcp",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean MCP server - run checks and fetch facts for AI agents",

--- a/packages/redaction/deno.json
+++ b/packages/redaction/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/redaction",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Redaction Engine - Plugin-based secrets/PII detection and masking",

--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/runner",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Runner - Test executor with sandboxed Deno subprocess",
@@ -14,6 +14,7 @@
   "imports": {
     "@glubean/sdk": "jsr:@glubean/sdk@^0.12.0",
     "@std/cli": "jsr:@std/cli@^1.0.0",
-    "@std/assert": "jsr:@std/assert@^1.0.0"
+    "@std/assert": "jsr:@std/assert@^1.0.0",
+    "ky": "npm:ky@^1.14.0"
   }
 }

--- a/packages/runner/executor.ts
+++ b/packages/runner/executor.ts
@@ -2,6 +2,15 @@ import type { ApiTrace, GlubeanAction, GlubeanEvent } from "@glubean/sdk";
 import { resolveAllowNetFlag } from "./config.ts";
 import type { SharedRunConfig } from "./config.ts";
 
+/**
+ * Internal imports that harness.ts needs but consumers don't declare.
+ * These are merged into the consumer's deno.json when spawning the harness.
+ */
+const HARNESS_INTERNAL_IMPORTS: Record<string, string> = {
+  "@std/cli": "jsr:@std/cli@^1.0.0",
+  "ky": "npm:ky@^1.14.0",
+};
+
 // Constants
 const DEFAULT_CONCURRENCY = 1;
 const DEFAULT_TIMEOUT_MS = 30000; // 30 seconds
@@ -452,10 +461,64 @@ export class TestExecutor {
   private harnessPath: string;
   private options: ExecutorOptions;
 
+  private mergedConfigPath: string | undefined;
+
   constructor(options: ExecutorOptions = {}) {
     // Use full URL for JSR compatibility (pathname doesn't work with jsr: URLs)
     this.harnessPath = new URL("./harness.ts", import.meta.url).href;
     this.options = options;
+  }
+
+  /**
+   * Create a merged deno.json that includes both the consumer's config
+   * and the harness's internal dependencies. This ensures the harness
+   * subprocess can resolve its own imports (e.g. @std/cli, ky) without
+   * requiring consumers to declare them.
+   */
+  private async buildMergedConfig(): Promise<string | undefined> {
+    const configPath = this.options.configPath;
+    if (!configPath) return undefined;
+
+    try {
+      const raw = await Deno.readTextFile(configPath);
+      const config = JSON.parse(raw);
+      const imports = config.imports ?? {};
+
+      // Merge internal imports (consumer's declarations take precedence)
+      let needsMerge = false;
+      const merged = { ...imports };
+      for (const [key, value] of Object.entries(HARNESS_INTERNAL_IMPORTS)) {
+        if (!(key in merged)) {
+          merged[key] = value;
+          needsMerge = true;
+        }
+      }
+
+      if (!needsMerge) return configPath;
+
+      // Write merged config to a temp file next to the original
+      const dir = configPath.replace(/[/\\][^/\\]+$/, "");
+      const tmpPath = `${dir}/.glubean-merged-deno.json`;
+      const mergedConfig = { ...config, imports: merged };
+      await Deno.writeTextFile(tmpPath, JSON.stringify(mergedConfig, null, 2));
+      this.mergedConfigPath = tmpPath;
+      return tmpPath;
+    } catch {
+      // If we can't read/merge, fall back to original
+      return configPath;
+    }
+  }
+
+  /** Remove the temporary merged config file if it was created. */
+  private async cleanupMergedConfig(): Promise<void> {
+    if (this.mergedConfigPath) {
+      try {
+        await Deno.remove(this.mergedConfigPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+      this.mergedConfigPath = undefined;
+    }
   }
 
   /**
@@ -569,11 +632,10 @@ export class TestExecutor {
       }
     }
 
-    // GLUBEAN_DEV_CONFIG overrides the config path for local development,
-    // so the harness subprocess can resolve runner dependencies (e.g. ky)
-    // from the local workspace instead of the test project's deno.json.
-    const devConfig = Deno.env.get("GLUBEAN_DEV_CONFIG");
-    const effectiveConfig = devConfig || this.options.configPath;
+    // Merge harness internal dependencies into the consumer's deno.json
+    // so the subprocess can resolve @std/cli, ky, etc. without requiring
+    // consumers to declare them.
+    const effectiveConfig = await this.buildMergedConfig();
     if (effectiveConfig) {
       args.push(`--config=${effectiveConfig}`);
     }
@@ -785,6 +847,7 @@ export class TestExecutor {
       } catch {
         // Process may already be dead
       }
+      await this.cleanupMergedConfig();
     }
   }
 

--- a/packages/runner/harness.ts
+++ b/packages/runner/harness.ts
@@ -7,7 +7,7 @@
  */
 
 import { parseArgs } from "@std/cli/parse-args";
-import { ky } from "@glubean/sdk";
+import ky from "ky";
 import {
   classifyHostnameBlockReason,
   classifyIpBlockReason,

--- a/packages/scanner/deno.json
+++ b/packages/scanner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/scanner",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "exports": {
     ".": "./mod.ts",
     "./static": "./static.ts"

--- a/packages/sdk/deno.json
+++ b/packages/sdk/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/sdk",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts",

--- a/packages/sdk/mod.ts
+++ b/packages/sdk/mod.ts
@@ -1514,8 +1514,3 @@ export { definePlugin } from "./plugin.ts";
 // Re-export assertion utilities
 export { Expectation, ExpectFailError } from "./expect.ts";
 export type { AssertEmitter, AssertionEmission, CustomMatchers, MatcherFn, MatcherResult } from "./expect.ts";
-
-// Re-export ky — SDK wraps ky for HTTP, so it's a first-class dependency.
-// This ensures runner/harness can import ky via SDK without requiring users
-// to declare ky in their own deno.json.
-export { default as ky } from "ky";

--- a/packages/worker/deno.json
+++ b/packages/worker/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/worker",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "exports": {
     ".": "./mod.ts",
     "./cli": "./cli.ts"


### PR DESCRIPTION
## Summary
- Executor now generates a merged deno.json that includes harness internal deps (`@std/cli`, `ky`) so consumers don't need to declare them
- Harness imports `ky` directly instead of re-exporting from SDK
- Removed SDK's `ky` re-export (no longer needed)
- Includes version bump to 0.12.9

## Test plan
- [x] `deno test -A packages/runner/` — 151 passed
- [x] `deno test -A packages/sdk/` — 305 passed
- [x] Verified whoami test runs with trace output via CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)