### PR TITLE
chore: bump version to 0.12.10

### DIFF
--- a/packages/auth/deno.json
+++ b/packages/auth/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/auth",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",

--- a/packages/graphql/deno.json
+++ b/packages/graphql/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/graphql",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts"

--- a/packages/mcp/deno.json
+++ b/packages/mcp/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/mcp",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean MCP server - run checks and fetch facts for AI agents",

--- a/packages/redaction/deno.json
+++ b/packages/redaction/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/redaction",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Redaction Engine - Plugin-based secrets/PII detection and masking",

--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/runner",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean Runner - Test executor with sandboxed Deno subprocess",

--- a/packages/scanner/deno.json
+++ b/packages/scanner/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/scanner",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "exports": {
     ".": "./mod.ts",
     "./static": "./static.ts"

--- a/packages/sdk/deno.json
+++ b/packages/sdk/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/sdk",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "exports": {
     ".": "./mod.ts",
     "./data": "./data.ts",

--- a/packages/worker/deno.json
+++ b/packages/worker/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/worker",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "exports": {
     ".": "./mod.ts",
     "./cli": "./cli.ts"


### PR DESCRIPTION
## Summary
- Patch bump to retrigger auto-publish with fixed workflow (two-pass publishing)
- Includes mcp scanner dependency fix from #80

## Test plan
- [x] CI tests pass
- [x] Auto-publish workflow should succeed with retry logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)