### PR TITLE
fix: run deno install after glubean init

### DIFF
--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -442,6 +442,35 @@ PASSWORD=
 `;
 
 // ---------------------------------------------------------------------------
+// Dependency installation
+// ---------------------------------------------------------------------------
+
+async function installDependencies(): Promise<void> {
+  console.log(
+    `\n${colors.dim}Installing dependencies...${colors.reset}`,
+  );
+  const cmd = new Deno.Command("deno", {
+    args: ["install"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const result = await cmd.output();
+  if (result.success) {
+    console.log(
+      `  ${colors.green}✓${colors.reset} Dependencies installed\n`,
+    );
+  } else {
+    const stderr = new TextDecoder().decode(result.stderr);
+    console.log(
+      `  ${colors.yellow}⚠${colors.reset} Failed to install dependencies. Run ${colors.cyan}deno install${colors.reset} manually.`,
+    );
+    if (stderr.trim()) {
+      console.log(`  ${colors.dim}${stderr.trim()}${colors.reset}\n`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Options
 // ---------------------------------------------------------------------------
 
@@ -858,6 +887,8 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
   );
 
   if (created > 0) {
+    await installDependencies();
+
     console.log(`${colors.bold}Next steps:${colors.reset}`);
     console.log(
       `  1. Run ${colors.cyan}deno task test${colors.reset} to run all tests in tests/`,
@@ -998,6 +1029,8 @@ async function initMinimal(overwrite: boolean): Promise<void> {
   );
 
   if (created > 0) {
+    await installDependencies();
+
     console.log(`${colors.bold}Next steps:${colors.reset}`);
     console.log(
       `  1. Run ${colors.cyan}deno task explore${colors.reset} to run all explore tests`,


### PR DESCRIPTION
## Summary
- Run `deno install` automatically after `glubean init` to cache `@glubean/sdk` dependencies
- Fixes VSCode Deno LSP type errors that appear immediately after project initialization
- Applies to both standard and minimal init paths, with graceful fallback on failure

## Test plan
- [x] `deno check` passes
- [x] Verified `deno install` resolves the type errors in a fresh project

🤖 Generated with [Claude Code](https://claude.com/claude-code)