### PR TITLE
feat: HttpResponse type, skill template, spec split

### DIFF
--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -796,6 +796,11 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
       content: () => readCliTemplate("AI-INSTRUCTIONS.md"),
       description: "AI instructions (Codex, other agents)",
     },
+    {
+      path: ".claude/skills/gb/SKILL.md",
+      content: () => readCliTemplate("claude-skill-glubean-test.md"),
+      description: "Claude Code skill — /gb test generator",
+    },
   ];
 
   if (enableHooks) {
@@ -987,6 +992,11 @@ async function initMinimal(overwrite: boolean): Promise<void> {
       path: "AGENTS.md",
       content: () => readCliTemplate("AI-INSTRUCTIONS.md"),
       description: "AI instructions (Codex, other agents)",
+    },
+    {
+      path: ".claude/skills/gb/SKILL.md",
+      content: () => readCliTemplate("claude-skill-glubean-test.md"),
+      description: "Claude Code skill — /gb test generator",
     },
   ];
 

--- a/packages/cli/commands/spec_split.ts
+++ b/packages/cli/commands/spec_split.ts
@@ -1,0 +1,91 @@
+/**
+ * `glubean spec split <spec>` — dereference $refs and split an OpenAPI spec
+ * into per-endpoint JSON files for efficient AI consumption.
+ *
+ * Output: context/<basename>-endpoints/
+ *   ├── _index.md
+ *   ├── get-users.json
+ *   ├── post-users.json
+ *   └── ...
+ */
+
+import { basename, dirname, extname, resolve } from "@std/path";
+import { parseSpec, splitSpec } from "../lib/openapi_split.ts";
+
+const colors = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+};
+
+export interface SpecSplitOptions {
+  output?: string;
+}
+
+export async function specSplitCommand(
+  specPath: string,
+  options: SpecSplitOptions = {},
+): Promise<void> {
+  const absSpec = resolve(specPath);
+
+  // Read and parse spec
+  let content: string;
+  try {
+    content = await Deno.readTextFile(absSpec);
+  } catch {
+    console.error(`Error: Cannot read spec file: ${specPath}`);
+    Deno.exit(1);
+  }
+
+  let spec: Record<string, unknown>;
+  try {
+    spec = parseSpec(content, absSpec);
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    Deno.exit(1);
+  }
+
+  if (!spec || typeof spec !== "object") {
+    console.error("Error: Spec file did not parse to a valid object.");
+    Deno.exit(1);
+  }
+
+  if (!spec.paths || typeof spec.paths !== "object" || Object.keys(spec.paths).length === 0) {
+    console.error("Error: No paths found in spec. Is this an OpenAPI 3.x file?");
+    Deno.exit(1);
+  }
+
+  // Determine output directory
+  const specBasename = basename(absSpec, extname(absSpec));
+  const outDir = options.output ? resolve(options.output) : resolve(dirname(absSpec), `${specBasename}-endpoints`);
+
+  // Split
+  const { endpoints, index } = splitSpec(spec);
+
+  // Write files
+  await Deno.mkdir(outDir, { recursive: true });
+
+  // Write index
+  await Deno.writeTextFile(resolve(outDir, "_index.md"), index);
+  console.log(
+    `  ${colors.green}create${colors.reset} _index.md`,
+  );
+
+  // Write endpoint files
+  for (const ep of endpoints) {
+    const filePath = resolve(outDir, `${ep.slug}.json`);
+    await Deno.writeTextFile(filePath, JSON.stringify(ep.content, null, 2) + "\n");
+    console.log(
+      `  ${colors.green}create${colors.reset} ${ep.slug}.json`,
+    );
+  }
+
+  const relOut = outDir.startsWith(Deno.cwd()) ? outDir.slice(Deno.cwd().length + 1) : outDir;
+
+  console.log(
+    `\n${colors.bold}Done:${colors.reset} ${endpoints.length} endpoints → ${colors.cyan}${relOut}/${colors.reset}`,
+  );
+}

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@glubean/cli",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "exports": "./mod.ts",
   "license": "MIT",
   "description": "Glubean CLI - Run and sync API tests from the command line",

--- a/packages/cli/lib/openapi_split.ts
+++ b/packages/cli/lib/openapi_split.ts
@@ -1,0 +1,262 @@
+/**
+ * OpenAPI Spec Splitter — dereference $refs and split into per-endpoint files.
+ *
+ * Input:  a single OpenAPI 3.x spec (JSON or YAML)
+ * Output: one JSON file per operation + an _index.md summary
+ */
+
+import { parse as yamlParse } from "@std/yaml";
+
+// deno-lint-ignore no-explicit-any
+type AnyObj = Record<string, any>;
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options", "trace"];
+
+// ---------------------------------------------------------------------------
+// $ref resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a JSON pointer like "#/components/schemas/User" against the root doc.
+ */
+function resolvePointer(root: AnyObj, ref: string): unknown {
+  if (!ref.startsWith("#/")) return undefined;
+  const parts = ref.slice(2).split("/");
+  let current: unknown = root;
+  for (const part of parts) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as AnyObj)[part];
+  }
+  return current;
+}
+
+/**
+ * Deep-dereference: recursively replace all $ref with their resolved values.
+ * Tracks visited refs to avoid infinite loops on circular references.
+ */
+function deref(node: unknown, root: AnyObj, visited: Set<string> = new Set()): unknown {
+  if (node == null || typeof node !== "object") return node;
+
+  if (Array.isArray(node)) {
+    return node.map((item) => deref(item, root, visited));
+  }
+
+  const obj = node as AnyObj;
+
+  // Handle $ref
+  if (typeof obj["$ref"] === "string") {
+    const ref = obj["$ref"] as string;
+    if (visited.has(ref)) {
+      // Circular reference — return a marker instead of infinite recursion
+      return { _circular_ref: ref };
+    }
+    const resolved = resolvePointer(root, ref);
+    if (resolved === undefined) return obj; // unresolvable, keep as-is
+    visited.add(ref);
+    const result = deref(resolved, root, new Set(visited));
+    return result;
+  }
+
+  // Recurse into all properties
+  const result: AnyObj = {};
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] = deref(value, root, visited);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Split
+// ---------------------------------------------------------------------------
+
+export interface EndpointFile {
+  /** Filename without extension, e.g. "get-users-id" */
+  slug: string;
+  /** The fully dereferenced operation object */
+  content: AnyObj;
+}
+
+export interface SplitResult {
+  endpoints: EndpointFile[];
+  index: string; // Markdown index content
+}
+
+/**
+ * Convert path + method to a filename slug.
+ * e.g. "/users/{id}/posts" + "get" → "get-users-id-posts"
+ */
+function toSlug(path: string, method: string): string {
+  return (
+    method +
+    "-" +
+    path
+      .replace(/^\//, "")
+      .replace(/\{([^}]+)\}/g, "$1")
+      .replace(/[^a-zA-Z0-9]+/g, "-")
+      .replace(/-+$/, "")
+      .toLowerCase()
+  );
+}
+
+/**
+ * Split an OpenAPI spec into per-endpoint files with all $refs resolved.
+ */
+export function splitSpec(spec: AnyObj): SplitResult {
+  const paths = spec.paths;
+  if (!paths || typeof paths !== "object") {
+    return { endpoints: [], index: "# API Endpoints Index\n\nNo paths found.\n" };
+  }
+
+  const endpoints: EndpointFile[] = [];
+  const slugCounts = new Map<string, number>();
+  const warnings: string[] = [];
+
+  // Group by tag for index
+  const tagGroups = new Map<string, { method: string; path: string; slug: string; summary: string }[]>();
+
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (!pathItem || typeof pathItem !== "object") continue;
+    const pathObj = pathItem as AnyObj;
+
+    // Collect path-level parameters (shared across methods)
+    let pathParams: AnyObj[] | undefined;
+    if (Array.isArray(pathObj.parameters)) {
+      pathParams = deref(pathObj.parameters, spec) as AnyObj[];
+      if (!Array.isArray(pathParams)) pathParams = undefined;
+    }
+
+    for (const method of HTTP_METHODS) {
+      const operation = pathObj[method];
+      if (!operation || typeof operation !== "object") continue;
+
+      // Deduplicate slugs
+      let slug = toSlug(path, method);
+      const count = slugCounts.get(slug) || 0;
+      slugCounts.set(slug, count + 1);
+      if (count > 0) {
+        slug = `${slug}-${count + 1}`;
+      }
+
+      let derefOp: AnyObj;
+      try {
+        derefOp = deref(operation, spec) as AnyObj;
+      } catch {
+        warnings.push(`Warning: Failed to dereference ${method.toUpperCase()} ${path}, skipping`);
+        continue;
+      }
+
+      // Build self-contained endpoint doc
+      const endpoint: AnyObj = {
+        path,
+        method: method.toUpperCase(),
+        ...derefOp,
+      };
+
+      // Merge path-level parameters
+      if (pathParams) {
+        const opParams = Array.isArray(endpoint.parameters) ? endpoint.parameters : [];
+        const opParamKeys = new Set(
+          opParams
+            .filter((p: AnyObj) => p && typeof p === "object" && p.in && p.name)
+            .map((p: AnyObj) => `${p.in}:${p.name}`),
+        );
+        const merged = [
+          ...opParams,
+          ...pathParams.filter(
+            (p: AnyObj) =>
+              p && typeof p === "object" && p.in && p.name &&
+              !opParamKeys.has(`${p.in}:${p.name}`),
+          ),
+        ];
+        endpoint.parameters = merged;
+      }
+
+      // Include relevant security schemes
+      const security = endpoint.security || spec.security;
+      if (Array.isArray(security) && spec.components?.securitySchemes) {
+        const schemeNames = new Set<string>();
+        for (const req of security) {
+          if (req && typeof req === "object") {
+            for (const name of Object.keys(req)) {
+              schemeNames.add(name);
+            }
+          }
+        }
+        const schemes: AnyObj = {};
+        for (const name of schemeNames) {
+          if (spec.components.securitySchemes[name]) {
+            try {
+              schemes[name] = deref(spec.components.securitySchemes[name], spec);
+            } catch {
+              // Skip unresolvable security scheme
+            }
+          }
+        }
+        if (Object.keys(schemes).length > 0) {
+          endpoint._securitySchemes = schemes;
+        }
+      }
+
+      // Include servers if present
+      if (spec.servers) {
+        endpoint._servers = spec.servers;
+      }
+
+      endpoints.push({ slug, content: endpoint });
+
+      // Index grouping
+      const tags = Array.isArray(derefOp.tags) ? derefOp.tags : ["untagged"];
+      const summary = derefOp.summary || derefOp.operationId || "";
+      for (const tag of tags) {
+        const tagStr = String(tag);
+        if (!tagGroups.has(tagStr)) tagGroups.set(tagStr, []);
+        tagGroups.get(tagStr)!.push({ method: method.toUpperCase(), path, slug, summary: String(summary) });
+      }
+    }
+  }
+
+  // Build index markdown
+  const lines: string[] = ["# API Endpoints Index", ""];
+
+  if (warnings.length > 0) {
+    lines.push("## Warnings", "");
+    for (const w of warnings) {
+      lines.push(`- ${w}`);
+    }
+    lines.push("");
+  }
+
+  // Sort tags alphabetically
+  const sortedTags = [...tagGroups.keys()].sort();
+  for (const tag of sortedTags) {
+    lines.push(`## ${tag}`, "");
+    const ops = tagGroups.get(tag)!;
+    for (const op of ops) {
+      lines.push(`- ${op.method} ${op.path} → \`${op.slug}.json\` — ${op.summary}`);
+    }
+    lines.push("");
+  }
+
+  return { endpoints, index: lines.join("\n") };
+}
+
+// ---------------------------------------------------------------------------
+// Parse input spec
+// ---------------------------------------------------------------------------
+
+export function parseSpec(content: string, filePath: string): AnyObj {
+  const ext = filePath.toLowerCase();
+  try {
+    if (ext.endsWith(".yaml") || ext.endsWith(".yml")) {
+      const parsed = yamlParse(content);
+      if (!parsed || typeof parsed !== "object") {
+        throw new Error("YAML parsed to a non-object value");
+      }
+      return parsed as AnyObj;
+    }
+    return JSON.parse(content);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to parse spec (${ext.endsWith(".json") ? "JSON" : "YAML"}): ${msg}`);
+  }
+}

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -5,6 +5,10 @@
  * argument validation, and shell completions.
  */
 
+// Support running from outside workspace (e.g. shell alias with GLUBEAN_CWD)
+const _cwd = Deno.env.get("GLUBEAN_CWD");
+if (_cwd) Deno.chdir(_cwd);
+
 import { Command, EnumType } from "@cliffy/command";
 import { initCommand } from "./commands/init.ts";
 import { runCommand } from "./commands/run.ts";
@@ -17,6 +21,7 @@ import { workerCommand } from "./commands/worker.ts";
 import { upgradeCommand } from "./commands/upgrade.ts";
 import { loginCommand } from "./commands/login.ts";
 import { patchCommand } from "./commands/patch.ts";
+import { specSplitCommand } from "./commands/spec_split.ts";
 import { CLI_VERSION } from "./version.ts";
 import { abortUpdateCheck, checkForUpdates } from "./update_check.ts";
 
@@ -308,6 +313,27 @@ cli
       format: options.format as "json" | "yaml" | undefined,
     });
   });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// spec command (with subcommands)
+// ─────────────────────────────────────────────────────────────────────────────
+const specCmd = new Command()
+  .description("OpenAPI spec tools")
+  .action(() => {
+    specCmd.showHelp();
+  });
+
+specCmd
+  .command(
+    "split <spec:string>",
+    "Dereference $refs and split spec into per-endpoint files for AI",
+  )
+  .option("-o, --output <dir:string>", "Output directory (default: <name>-endpoints/ next to spec)")
+  .action(async (options, spec: string) => {
+    await specSplitCommand(spec, { output: options.output });
+  });
+
+cli.command("spec", specCmd);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // upgrade command

--- a/packages/cli/templates/claude-skill-glubean-test.md
+++ b/packages/cli/templates/claude-skill-glubean-test.md
@@ -1,0 +1,382 @@
+---
+name: gb
+description: Generate Glubean API tests from OpenAPI specs or user instructions. Reads context/, writes tests, runs them via MCP, and fixes failures automatically.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - mcp__glubean__glubean_run_local_file
+  - mcp__glubean__glubean_discover_tests
+  - mcp__glubean__glubean_list_test_files
+  - mcp__glubean__glubean_diagnose_config
+  - mcp__glubean__glubean_get_last_run_summary
+  - mcp__glubean__glubean_get_local_events
+---
+
+# Glubean Test Generator
+
+You are a Glubean test expert. Generate, run, and fix API tests using `@glubean/sdk`.
+
+## Your workflow
+
+1. **Read the API spec** — first check for `context/*-endpoints/_index.md` (pre-split specs). If found, read the index
+   and only open the specific endpoint file you need. If no split endpoints exist, search `context/` for OpenAPI specs
+   (`.json`, `.yaml`). If a spec is larger than 50K, suggest the user run `glubean spec split context/<file>` first. If
+   no spec found, ask the user for endpoint details.
+2. **Read existing tests** — check `tests/` and `explore/` for patterns, configure files, and naming conventions already
+   in use.
+3. **Write tests** — generate test files following the SDK API and conventions below.
+4. **Run tests** — use MCP tool `glubean_run_local_file` to execute. If MCP is unavailable, use `deno task test` via
+   Bash.
+5. **Fix failures** — read the structured failure output, fix the test code, and rerun. Repeat until green.
+
+If $ARGUMENTS is provided, treat it as the target: an endpoint path, a tag, a file to test, or a natural language
+description.
+
+## Project structure
+
+```
+tests/           # Permanent test files (*.test.ts)
+explore/         # Exploratory tests (same format, for iteration)
+data/            # Test data files (JSON, CSV, YAML)
+context/         # OpenAPI specs and reference docs
+.env             # Public variables (BASE_URL)
+.env.secrets     # Credentials — gitignored
+deno.json        # Runtime config, imports, glubean settings
+```
+
+## Import convention
+
+Always use the import map alias from `deno.json`:
+
+```typescript
+import { configure, fromCsv, fromDir, fromYaml, test } from "@glubean/sdk";
+```
+
+Never use `jsr:` URLs directly.
+
+---
+
+## SDK API Reference
+
+### test()
+
+```typescript
+// Quick mode — single function
+export const myTest = test(
+  { id: "kebab-case-id", name: "Human name", tags: ["api"] },
+  async (ctx) => { ... }
+);
+
+// Builder mode — multi-step
+export const myFlow = test("flow-id")
+  .meta({ name: "Flow name", tags: ["api"] })
+  .setup(async (ctx) => { return { token: "..." }; })
+  .step("step-name", async (ctx, state) => { return { ...state, new: "data" }; })
+  .teardown(async (ctx, state) => { /* cleanup, always runs */ });
+
+// Reusable steps with .use() — extract common sequences into plain functions
+const withAuth = (b: TestBuilder<unknown>) => b
+  .step("login", async (ctx) => {
+    const { token } = await ctx.http.post("/login", { json: { ... } }).json<{ token: string }>();
+    return { token };
+  });
+
+export const testA = test("test-a").use(withAuth).step("act", async (ctx, { token }) => { ... });
+export const testB = test("test-b").use(withAuth).step("verify", async (ctx, { token }) => { ... });
+
+// .group(id, fn) — same as .use() but tags steps for visual grouping in reports
+export const checkout = test("checkout")
+  .group("auth", withAuth)
+  .step("pay", async (ctx, { token }) => { ... });
+// Report: checkout → [auth] login → pay
+```
+
+### TestContext (ctx)
+
+```typescript
+ctx.http                              // HTTP client (auto-traces)
+ctx.expect(value)                     // Soft assertion
+ctx.assert(condition, message?)       // Hard assertion
+ctx.log(message, data?)               // Structured log
+ctx.vars.require("KEY")              // Read env var (throws if missing)
+ctx.secrets.require("KEY")           // Read secret (auto-redacted)
+ctx.metric("name", value, { unit? }) // Record metric
+ctx.validate(data, zodSchema)        // Schema validation
+ctx.pollUntil({ timeoutMs }, fn)     // Poll until truthy
+ctx.skip(reason?)                    // Skip test
+```
+
+### HTTP Client
+
+```typescript
+const res = await ctx.http.get(url, options?);
+const data = await ctx.http.post(url, { json: { ... } }).json<T>();
+// Also: .put(), .patch(), .delete()
+// Response: .json<T>(), .text(), .blob()
+```
+
+Options:
+
+```typescript
+{
+  json: { ... },                    // JSON body
+  searchParams: { key: "value" },   // Query params
+  headers: { "X-Custom": "val" },   // Headers
+  timeout: 5000,                    // ms
+  retry: 3,                         // Retry count
+}
+```
+
+Extend with defaults:
+
+```typescript
+const authed = ctx.http.extend({
+  headers: { Authorization: `Bearer ${token}` },
+});
+```
+
+### Assertions — ctx.expect()
+
+```typescript
+expect(x).toBe(y); // Strict equal
+expect(x).toEqual(y); // Deep equal
+expect(x).toBeTruthy();
+expect(x).toBeDefined();
+expect(n).toBeGreaterThan(5);
+expect(s).toContain("sub");
+expect(s).toMatch(/regex/);
+expect(arr).toHaveLength(3);
+expect(obj).toMatchObject({ key: "val" });
+expect(obj).toHaveProperty("path.to.key");
+expect(res).toHaveStatus(200); // HTTP response
+expect(x).not.toBe(y); // Negate
+expect(x).toBe(y).orFail(); // Hard fail (stop test)
+```
+
+### configure() — shared HTTP client
+
+```typescript
+// config/api.ts or tests/configure.ts
+import { configure } from "@glubean/sdk";
+
+export const { http, vars, secrets } = configure({
+  vars: { baseUrl: "BASE_URL" },
+  secrets: { apiKey: "API_KEY" },
+  http: {
+    prefixUrl: "BASE_URL", // Env var name
+    headers: {
+      Authorization: "Bearer {{API_KEY}}", // {{var}} interpolation
+    },
+  },
+});
+```
+
+### Data loading
+
+```typescript
+const rows = await fromDir<T>("./data/users/"); // One JSON file = one row
+const cases = await fromDir.merge<T>("./data/search/"); // Merged for test.pick
+const csv = await fromCsv<T>("./data/file.csv");
+const yaml = await fromYaml<T>("./data/file.yaml");
+```
+
+**Data file formats:**
+
+`fromDir` — each file is one row. File content is a flat object:
+
+```json
+// data/users/alice.json — becomes one row with _name="alice"
+{ "username": "alice", "role": "admin", "expected": 200 }
+```
+
+`fromDir.merge` — each file contains named examples as top-level keys. Keys = pick names, values = scenario objects. All
+files are shallow-merged into one map:
+
+```json
+// data/search/queries.json
+{
+  "by-name":     { "q": "phone", "expected": "phone" },
+  "by-category": { "q": "laptop", "expected": "laptop" }
+}
+// data/search/edge-cases.json
+{
+  "empty-query": { "q": "", "expected": "" }
+}
+// → merged result: { "by-name": {...}, "by-category": {...}, "empty-query": {...} }
+```
+
+Inline examples (no data file needed):
+
+```typescript
+// test.each — array of objects
+test.each([
+  { id: 1, expected: 200 },
+  { id: 999, expected: 404 },
+])("get-user-$id", async (ctx, { id, expected }) => { ... });
+
+// test.pick — object with named keys
+test.pick({
+  "normal":    { name: "Alice", age: 25 },
+  "edge-case": { name: "", age: -1 },
+})("create-user-$_pick", async (ctx, data) => { ... });
+```
+
+### test.each — data-driven
+
+```typescript
+// Quick mode — single function per row
+const users = await fromDir<{ username: string }>("./data/users/");
+export const tests = test.each(users)(
+  "user-lookup-$username",           // $field interpolates
+  async (ctx, { username }) => { ... },
+);
+
+// Builder mode — multi-step per row (omit callback to get builder)
+export const flows = test.each(users)("user-flow-$username")
+  .step("fetch", async (ctx, _state, row) => {
+    const res = await ctx.http.get(`/users/${row.username}`).json<{ id: string }>();
+    return { id: res.id };
+  })
+  .step("verify", async (ctx, state, row) => {
+    ctx.expect(state.id).toBeDefined();
+  });
+```
+
+### test.pick — named examples
+
+```typescript
+// Quick mode — single function
+const cases = await fromDir.merge<{ q: string }>("./data/search/");
+export const tests = test.pick(cases)(
+  "search-$_pick",                   // $_pick = case name
+  async (ctx, { q }) => { ... },
+);
+
+// Builder mode — multi-step per picked example (omit callback to get builder)
+export const flows = test.pick(cases)("search-flow-$_pick")
+  .setup(async (ctx, row) => ({ query: row.q }))
+  .step("search", async (ctx, state, row) => {
+    const res = await ctx.http.get("/search", { searchParams: { q: state.query } }).json<{ total: number }>();
+    return { ...state, total: res.total };
+  })
+  .step("verify", async (ctx, state) => {
+    ctx.expect(state.total).toBeGreaterThan(0);
+  })
+  .teardown(async (ctx, state) => { /* cleanup */ });
+```
+
+Both `test.each` and `test.pick` support the same builder API as `test()`. Omit the callback to enter builder mode;
+chain `.step()`, `.setup()`, `.teardown()`, `.meta()`, etc.
+
+---
+
+## Patterns
+
+### Simple API test
+
+```typescript
+import { test } from "@glubean/sdk";
+import { http } from "./configure.ts";
+
+export const listUsers = test(
+  { id: "list-users", tags: ["api", "smoke"] },
+  async ({ expect }) => {
+    const users = await http.get("users").json<{ users: unknown[] }>();
+    expect(users.users.length).toBeGreaterThan(0);
+  },
+);
+```
+
+### CRUD with cleanup
+
+```typescript
+export const crud = test("resource-crud")
+  .meta({ tags: ["api"] })
+  .setup(async () => {
+    const item = await http.post("items", { json: { name: "test" } }).json<{ id: string }>();
+    return { id: item.id };
+  })
+  .step("read", async ({ expect }, state) => {
+    const item = await http.get(`items/${state.id}`).json<{ name: string }>();
+    expect(item.name).toBe("test");
+    return state;
+  })
+  .step("update", async ({ expect }, state) => {
+    const item = await http.put(`items/${state.id}`, { json: { name: "updated" } }).json<{ name: string }>();
+    expect(item.name).toBe("updated");
+    return state;
+  })
+  .teardown(async (_ctx, state) => {
+    if (state?.id) await http.delete(`items/${state.id}`);
+  });
+```
+
+### Auth flow
+
+```typescript
+export const auth = test("auth-flow")
+  .meta({ tags: ["api", "auth"] })
+  .step("login", async ({ http, expect, secrets }) => {
+    const res = await http.post("https://api.example.com/auth/login", {
+      json: { username: secrets.require("USERNAME"), password: secrets.require("PASSWORD") },
+    }).json<{ token: string }>();
+    expect(res.token).toBeDefined();
+    return { token: res.token };
+  })
+  .step("access protected", async ({ http, expect }, state) => {
+    const authed = http.extend({ headers: { Authorization: `Bearer ${state.token}` } });
+    const profile = await authed.get("https://api.example.com/me").json<{ id: string }>();
+    expect(profile.id).toBeDefined();
+  });
+```
+
+### Error / negative test
+
+```typescript
+export const unauthorized = test(
+  { id: "unauthorized-access", tags: ["api", "auth"] },
+  async ({ http, expect }) => {
+    const res = await http.get("https://api.example.com/protected");
+    expect(res).toHaveStatus(401);
+  },
+);
+```
+
+---
+
+## Rules
+
+- **IDs**: kebab-case, unique across the project
+- **Tags**: always set — `["smoke"]`, `["api"]`, `["e2e"]`, `["auth"]`
+- **Secrets**: use `secrets.require("KEY")` or `{{KEY}}` in configure. Never hardcode.
+- **Cleanup**: any test that creates data MUST have `.teardown()`
+- **Data**: keep test data in `data/`, not inline in test files
+- **Imports**: use `.ts` extensions for local files
+- **One export per behavior**: each `export const` is one test case
+
+## Coverage expectations
+
+For each endpoint, consider:
+
+- Success path (200/201)
+- Auth boundary (401/403) — missing or invalid credentials
+- Validation boundary (400/422) — invalid input
+- Not-found boundary (404) — nonexistent resource
+
+Cover all applicable boundaries unless the user asks for a narrower scope. If the spec lacks detail for a negative case,
+say so explicitly.
+
+## Anti-patterns to avoid
+
+- Hardcoded secrets or base URLs
+- Using raw `fetch()` instead of `ctx.http` or configured client
+- No tags on tests
+- Creating resources without teardown cleanup
+- Guessing endpoint paths — always check the spec first
+- Using `jsr:` URLs instead of `@glubean/sdk` alias
+- Using `any` or `unknown` for HTTP response types — always provide a type parameter: `.json<{ id: string }>()`, not
+  `.json<any>()`. The SDK is fully typed; if you know the shape from the spec, type it.

--- a/packages/sdk/types.ts
+++ b/packages/sdk/types.ts
@@ -1184,20 +1184,38 @@ export type ReservedConfigureKeys = "vars" | "secrets" | "http";
 // =============================================================================
 
 /**
- * Promise returned by HTTP client methods.
- * Extends native `Promise<Response>` with convenience body-parsing methods.
+ * Response object returned when awaiting HTTP client methods.
+ * Extends native `Response` with a typed `.json<T>()` method so you can
+ * assert on status first, then parse with a type parameter:
  *
- * @example Parse JSON response
+ * ```ts
+ * const res = await ctx.http.post(url, { json: body });
+ * ctx.expect(res).toHaveStatus(200);
+ * const data = await res.json<{ id: string }>();
+ * ```
+ */
+export interface HttpResponse extends Response {
+  /** Parse response body as JSON with optional type parameter */
+  json<T = unknown>(): Promise<T>;
+}
+
+/**
+ * Promise returned by HTTP client methods.
+ * Extends native `Promise<HttpResponse>` with convenience body-parsing methods.
+ *
+ * @example Chain directly
  * ```ts
  * const users = await ctx.http.get(`${baseUrl}/users`).json<User[]>();
  * ```
  *
- * @example Parse text response
+ * @example Await first, then parse (for asserting status before body)
  * ```ts
- * const html = await ctx.http.get(`${baseUrl}/page`).text();
+ * const res = await ctx.http.get(`${baseUrl}/users`);
+ * ctx.expect(res).toHaveStatus(200);
+ * const users = await res.json<User[]>();
  * ```
  */
-export interface HttpResponsePromise extends Promise<Response> {
+export interface HttpResponsePromise extends Promise<HttpResponse> {
   /** Parse response body as JSON */
   json<T = unknown>(): Promise<T>;
   /** Parse response body as text */


### PR DESCRIPTION
## Summary
- **SDK**: Add `HttpResponse` interface extending `Response` with typed `.json<T>()`, so `await`-ed responses support generic parsing (fixes TS error when asserting status before parsing body)
- **CLI skill template**: Add builder mode examples for `test.each`/`test.pick`, data file format docs (`fromDir` vs `fromDir.merge`), `.use()`/`.group()` reusable step API, anti-pattern for `any`/`unknown` response types
- **CLI**: Add `glubean spec split` command for splitting large OpenAPI specs into per-endpoint files

## Test plan
- [x] `deno check packages/sdk/types.ts` passes
- [x] `deno fmt` passes
- [ ] Verify `res.json<T>()` works after `await` in a real test file
- [ ] Verify `glubean init` generates updated skill template

🤖 Generated with [Claude Code](https://claude.com/claude-code)